### PR TITLE
feat: Separate BIP-324 Protocol from MITM Logic

### DIFF
--- a/src/bip324/data_read.rs
+++ b/src/bip324/data_read.rs
@@ -17,7 +17,7 @@ pub enum DataReadState {
 }
 
 impl HasFinal for DataReadState {
-    /// Always returns false -- packet reading loops forever
+    /// Always returns false - packet reading loops forever
     fn is_final(&self) -> bool {
         false
     }

--- a/src/bip324/data_read.rs
+++ b/src/bip324/data_read.rs
@@ -1,0 +1,456 @@
+use std::cmp;
+
+use crate::cipher::{InboundCipher, LengthDecryptor};
+use crate::external::chacha20_poly1305::ChaCha20Poly1305Stream;
+use crate::protocol::{AADType, NUM_LENGTH_BYTES, NUM_TAG_BYTES, TagType};
+use crate::state_machine::{BufReader, HasFinal, ProtocolReadParser, ProtocolStatus};
+
+// Maximum packet size for automatic allocation.
+// Bitcoin Core's MAX_PROTOCOL_MESSAGE_LENGTH is 4,000,000 bytes (~4 MiB).
+// 14 extra bytes are for the BIP-324 header byte and 13 serialization header bytes (message type).
+const MAX_PACKET_SIZE_FOR_ALLOCATION: usize = 4000014;
+
+pub enum DataReadState {
+    ReceivingPacketLen(LengthDecryptor),
+    ReceivingPacketContent(ChaCha20Poly1305Stream),
+    ReceivingPacketTag(TagType),
+}
+
+impl HasFinal for DataReadState {
+    /// Always returns false -- packet reading loops forever
+    fn is_final(&self) -> bool {
+        false
+    }
+}
+
+pub struct DataReadParser {
+    state: Option<DataReadState>,
+    remaining: usize,
+    aad: Vec<u8>,
+    inbound_cipher: InboundCipher,
+
+    // Output buffers
+    output_length_bytes: Vec<u8>,
+    output_data_bytes: Vec<u8>,
+    output_tag_bytes: Vec<u8>,
+    output_aad: Option<Vec<u8>>,
+}
+
+impl DataReadParser {
+    pub fn new(aad: AADType, mut inbound_cipher: InboundCipher) -> Self {
+        let length_decryptor = inbound_cipher
+            .get_new_length_decryptor()
+            .expect("The inbound cipher can't create a length decryptor");
+        Self {
+            state: Some(DataReadState::ReceivingPacketLen(length_decryptor)),
+            remaining: NUM_LENGTH_BYTES,
+            aad,
+            inbound_cipher,
+            output_length_bytes: vec![],
+            output_data_bytes: vec![],
+            output_tag_bytes: vec![],
+            output_aad: None,
+        }
+    }
+
+    pub fn drain_length_bytes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output_length_bytes)
+    }
+
+    pub fn drain_data_bytes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output_data_bytes)
+    }
+
+    pub fn drain_tag_bytes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output_tag_bytes)
+    }
+
+    pub fn take_aad(&mut self) -> Option<Vec<u8>> {
+        self.output_aad.take()
+    }
+
+    pub fn set_aad(&mut self, aad: Vec<u8>) {
+        self.aad = aad;
+    }
+
+    fn consume_aad(&mut self) -> Vec<u8> {
+        self.aad.drain(..).collect()
+    }
+}
+
+impl ProtocolReadParser for DataReadParser {
+    type State = DataReadState;
+    type Error = ();
+
+    fn transition(
+        &mut self,
+        state: Self::State,
+        data: &mut dyn BufReader,
+    ) -> (Self::State, Result<ProtocolStatus, Self::Error>) {
+        use DataReadState::*;
+
+        let data_buf = data.buf_ref();
+        let to_consume = cmp::min(self.remaining, data_buf.len());
+        let mut data_to_process = data_buf[..to_consume].to_vec();
+        self.remaining -= to_consume;
+
+        let (next_state, res) = match state {
+            ReceivingPacketLen(mut length_decryptor) => {
+                // TODO: replace unwrap
+                length_decryptor
+                    .decrypt_len_part_inplace(&mut data_to_process)
+                    .unwrap();
+
+                self.output_length_bytes.extend_from_slice(&data_to_process);
+
+                match length_decryptor.try_end() {
+                    Ok((length_cipher, packet_len)) => {
+                        // TODO: replace unwrap
+                        self.inbound_cipher
+                            .reown_length_cipher(length_cipher)
+                            .unwrap();
+
+                        if packet_len > MAX_PACKET_SIZE_FOR_ALLOCATION {
+                            // TODO: replace panic
+                            panic!("Packet too big");
+                        }
+
+                        let stream_cipher = self
+                            .inbound_cipher
+                            .packet_cipher
+                            .start_one_payload_stream_encryption();
+
+                        // packet_len = plaintext_len + NUM_HEADER_BYTES + NUM_TAG_BYTES (from try_end).
+                        // Content phase reads header + plaintext only (not the tag).
+                        self.remaining = packet_len - NUM_TAG_BYTES;
+                        (
+                            ReceivingPacketContent(stream_cipher),
+                            Ok(ProtocolStatus::Continue),
+                        )
+                    }
+                    // Haven't received all 3 length bytes yet
+                    Err(new_length_decryptor) => (
+                        ReceivingPacketLen(new_length_decryptor),
+                        Ok(ProtocolStatus::End),
+                    ),
+                }
+            }
+            ReceivingPacketContent(mut stream_cipher) => {
+                stream_cipher.decrypt_and_store_chunk(&mut data_to_process);
+                self.output_data_bytes.extend_from_slice(&data_to_process);
+
+                if self.remaining == 0 {
+                    let aad = self.consume_aad();
+                    let tag = stream_cipher.get_tag(Some(&aad[..]));
+                    self.inbound_cipher.packet_cipher.end_current_stream(&aad);
+
+                    if !aad.is_empty() {
+                        self.output_aad = Some(aad);
+                    }
+
+                    self.remaining = NUM_TAG_BYTES;
+                    (
+                        ReceivingPacketTag(tag.to_vec()),
+                        Ok(ProtocolStatus::Continue),
+                    )
+                } else {
+                    (
+                        ReceivingPacketContent(stream_cipher),
+                        Ok(ProtocolStatus::End),
+                    )
+                }
+            }
+            ReceivingPacketTag(mut expected_tag) => {
+                if data_to_process != expected_tag[..data_to_process.len()] {
+                    // TODO: replace panic
+                    panic!("AEAD tag check fail");
+                }
+                expected_tag.drain(..data_to_process.len());
+
+                self.output_tag_bytes.extend_from_slice(&data_to_process);
+
+                if self.remaining == 0 {
+                    let length_decryptor = self
+                        .inbound_cipher
+                        .get_new_length_decryptor()
+                        .expect("The inbound cipher can't create a length decryptor");
+
+                    self.remaining = NUM_LENGTH_BYTES;
+                    (
+                        ReceivingPacketLen(length_decryptor),
+                        Ok(ProtocolStatus::Continue),
+                    )
+                } else {
+                    (ReceivingPacketTag(expected_tag), Ok(ProtocolStatus::End))
+                }
+            }
+        };
+
+        if res.is_ok() {
+            let _ = data.read(&mut vec![0u8; to_consume]).unwrap();
+        } else {
+            // TODO: see if you can represent this through typing
+            self.remaining += to_consume;
+        }
+
+        (next_state, res)
+    }
+
+    fn take_state(&mut self) -> Self::State {
+        self.state.take().unwrap()
+    }
+
+    fn set_state(&mut self, state: Self::State) {
+        self.state = Some(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::str::FromStr;
+    use secp256k1::SecretKey;
+    use secp256k1::ellswift::{ElligatorSwift, ElligatorSwiftParty};
+
+    use crate::cipher::{CipherSession, OutboundCipher, SessionKeyMaterial};
+    use crate::protocol::{PacketType, NUM_LENGTH_BYTES, NUM_TAG_BYTES, Role};
+    use crate::state_machine::StreamReadParser;
+
+    const MAGIC: [u8; 4] = [0xF9, 0xBE, 0xB4, 0xD9];
+
+    // Returns (alice_outbound [sender], bob_inbound [receiver]) using fixed known keys.
+    fn make_cipher_pair() -> (OutboundCipher, InboundCipher) {
+        let alice = SecretKey::from_str(
+            "61062ea5071d800bbfd59e2e8b53d47d194b095ae5a4df04936b49772ef0d4d7",
+        )
+        .unwrap();
+        let elliswift_alice = ElligatorSwift::from_str("ec0adff257bbfe500c188c80b4fdd640f6b45a482bbc15fc7cef5931deff0aa186f6eb9bba7b85dc4dcc28b28722de1e3d9108b985e2967045668f66098e475b").unwrap();
+        let elliswift_bob = ElligatorSwift::from_str("a4a94dfce69b4a2a0a099313d10f9f7e7d649d60501c9e1d274c300e0d89aafaffffffffffffffffffffffffffffffffffffffffffffffffffffffff8faf88d5").unwrap();
+        let session_keys = SessionKeyMaterial::from_ecdh(
+            elliswift_alice,
+            elliswift_bob,
+            alice,
+            ElligatorSwiftParty::A,
+            MAGIC,
+        )
+        .unwrap();
+        let alice_cipher = CipherSession::new(session_keys.clone(), Role::Initiator);
+        let bob_cipher = CipherSession::new(session_keys, Role::Responder);
+        let (_alice_inbound, alice_outbound) = alice_cipher.into_split();
+        let (bob_inbound, _bob_outbound) = bob_cipher.into_split();
+        (alice_outbound, bob_inbound)
+    }
+
+    fn encrypt_packet(outbound: &mut OutboundCipher, plaintext: &[u8]) -> Vec<u8> {
+        outbound.encrypt_to_vec(plaintext, PacketType::Genuine, None)
+    }
+
+    fn encrypt_packet_with_aad(outbound: &mut OutboundCipher, plaintext: &[u8], aad: &[u8]) -> Vec<u8> {
+        outbound.encrypt_to_vec(plaintext, PacketType::Genuine, Some(aad))
+    }
+
+    // Drain and check: length_bytes is 3 bytes, data_bytes is 1+plaintext.len(),
+    // tag_bytes is NUM_TAG_BYTES and matches the last 16 bytes of ciphertext.
+    fn assert_packet_outputs(
+        parser: &mut DataReadParser,
+        plaintext: &[u8],
+        ciphertext: &[u8],
+    ) {
+        let length_bytes = parser.drain_length_bytes();
+        let data_bytes = parser.drain_data_bytes();
+        let tag_bytes = parser.drain_tag_bytes();
+
+        assert_eq!(length_bytes.len(), NUM_LENGTH_BYTES, "length bytes length");
+        // data_bytes = header (1 byte) + decrypted plaintext (N bytes)
+        assert_eq!(data_bytes.len(), 1 + plaintext.len(), "data bytes length");
+        assert_eq!(data_bytes[0], 0x00, "genuine packet header byte");
+        assert_eq!(&data_bytes[1..], plaintext, "decrypted plaintext");
+        assert_eq!(tag_bytes.len(), NUM_TAG_BYTES, "tag bytes length");
+        // tag bytes are the raw network bytes (last 16 bytes of ciphertext)
+        assert_eq!(
+            tag_bytes,
+            &ciphertext[ciphertext.len() - NUM_TAG_BYTES..],
+            "tag bytes match ciphertext"
+        );
+    }
+
+    // 1. Encrypt a message with OutboundCipher. Feed encrypted bytes to DataReadParser. Drain
+    //    outputs. Verify length, data, tag match expectations.
+    #[test]
+    fn test_decrypt_single_packet() {
+        let (mut alice_out, bob_in) = make_cipher_pair();
+
+        let plaintext = b"hello bip324";
+        let ciphertext = encrypt_packet(&mut alice_out, plaintext);
+
+        let mut parser = DataReadParser::new(vec![], bob_in);
+        let mut data = &ciphertext[..];
+        parser.consume(&mut data).unwrap();
+
+        assert_packet_outputs(&mut parser, plaintext, &ciphertext);
+    }
+
+    // 2. Feed one encrypted byte at a time. Verify incremental output after each step.
+    #[test]
+    fn test_decrypt_byte_by_byte() {
+        let (mut alice_out, bob_in) = make_cipher_pair();
+
+        let plaintext = b"incremental";
+        let ciphertext = encrypt_packet(&mut alice_out, plaintext);
+
+        let mut parser = DataReadParser::new(vec![], bob_in);
+
+        let mut all_length = vec![];
+        let mut all_data = vec![];
+        let mut all_tag = vec![];
+
+        for byte in &ciphertext {
+            let mut slice = std::slice::from_ref(byte);
+            parser.step(&mut slice).unwrap();
+            all_length.extend(parser.drain_length_bytes());
+            all_data.extend(parser.drain_data_bytes());
+            all_tag.extend(parser.drain_tag_bytes());
+        }
+
+        assert_eq!(all_length.len(), NUM_LENGTH_BYTES);
+        assert_eq!(all_data.len(), 1 + plaintext.len());
+        assert_eq!(all_data[0], 0x00, "genuine packet header byte");
+        assert_eq!(&all_data[1..], plaintext.as_slice(), "decrypted plaintext");
+        assert_eq!(all_tag.len(), NUM_TAG_BYTES);
+        assert_eq!(
+            all_tag,
+            &ciphertext[ciphertext.len() - NUM_TAG_BYTES..],
+            "tag matches ciphertext"
+        );
+    }
+
+    // 3. Encrypt two messages. Feed each in a separate consume(). Verify both decrypted correctly.
+    #[test]
+    fn test_decrypt_multiple_packets() {
+        let (mut alice_out, bob_in) = make_cipher_pair();
+
+        let msg1 = b"first packet";
+        let msg2 = b"second packet";
+        let ct1 = encrypt_packet(&mut alice_out, msg1);
+        let ct2 = encrypt_packet(&mut alice_out, msg2);
+
+        let mut parser = DataReadParser::new(vec![], bob_in);
+
+        // Feed first packet
+        let mut data = &ct1[..];
+        parser.consume(&mut data).unwrap();
+        assert_packet_outputs(&mut parser, msg1, &ct1);
+
+        // Feed second packet
+        let mut data = &ct2[..];
+        parser.consume(&mut data).unwrap();
+        assert_packet_outputs(&mut parser, msg2, &ct2);
+    }
+
+    // 4. Create parser with non-empty AAD. Decrypt first packet (encrypted with matching AAD).
+    //    Verify take_aad() returns the AAD for first packet, None for second.
+    #[test]
+    fn test_aad_first_packet() {
+        let (mut alice_out, bob_in) = make_cipher_pair();
+
+        let garbage_aad: Vec<u8> = vec![0xAA; 32];
+        let mut parser = DataReadParser::new(garbage_aad.clone(), bob_in);
+
+        assert_eq!(parser.take_aad(), None, "No AAD before any packet");
+
+        // First packet: encrypt with the same AAD the parser will use for verification
+        let ct1 = encrypt_packet_with_aad(&mut alice_out, b"version", &garbage_aad);
+        let mut data = &ct1[..];
+        parser.consume(&mut data).unwrap();
+
+        assert_eq!(
+            parser.take_aad(),
+            Some(garbage_aad),
+            "AAD should be returned after first packet"
+        );
+        assert_eq!(parser.take_aad(), None, "take_aad() is one-shot");
+
+        // Second packet (no new AAD was set), encrypt with no AAD
+        let ct2 = encrypt_packet(&mut alice_out, b"second");
+        let mut data = &ct2[..];
+        parser.consume(&mut data).unwrap();
+
+        assert_eq!(
+            parser.take_aad(),
+            None,
+            "No AAD for second packet (none was set)"
+        );
+    }
+
+    // 5. Feed correct length + content, then corrupt tag bytes. Verify panic.
+    #[test]
+    #[should_panic(expected = "AEAD tag check fail")]
+    fn test_corrupt_tag_panics() {
+        let (mut alice_out, bob_in) = make_cipher_pair();
+
+        let plaintext = b"tag corruption test";
+        let mut ciphertext = encrypt_packet(&mut alice_out, plaintext);
+
+        // Corrupt all 16 tag bytes at the end
+        let len = ciphertext.len();
+        for byte in &mut ciphertext[len - NUM_TAG_BYTES..] {
+            *byte ^= 0xFF;
+        }
+
+        let mut parser = DataReadParser::new(vec![], bob_in);
+        let mut data = &ciphertext[..];
+        parser.consume(&mut data).unwrap();
+    }
+
+    // 6. Use known session keys. Verify the parser decodes the known ciphertext vector.
+    //    Matches test_vector_1 in cipher.rs: alice encrypts [0x8e] after one warmup packet,
+    //    producing ciphertext "7530d2a18720162ac09c25329a60d75adf36eda3c3".
+    #[test]
+    fn test_known_vectors() {
+        use hex::prelude::*;
+
+        let (mut alice_out, bob_in) = make_cipher_pair();
+
+        // Warmup: encrypt 100 bytes (matches test_vector_1 in cipher.rs which uses
+        // gen_garbage(100) before the known second packet)
+        let warmup_ct = encrypt_packet(&mut alice_out, &[0u8; 100]);
+
+        let contents: Vec<u8> = vec![0x8e];
+        let ct = encrypt_packet(&mut alice_out, &contents);
+        assert_eq!(
+            ct,
+            Vec::from_hex("7530d2a18720162ac09c25329a60d75adf36eda3c3").unwrap(),
+            "Known vector ciphertext mismatch"
+        );
+
+        let mut parser = DataReadParser::new(vec![], bob_in);
+
+        // Consume warmup packet
+        let mut data = &warmup_ct[..];
+        parser.consume(&mut data).unwrap();
+        parser.drain_length_bytes();
+        parser.drain_data_bytes();
+        parser.drain_tag_bytes();
+
+        // Consume known vector packet
+        let mut data = &ct[..];
+        parser.consume(&mut data).unwrap();
+
+        let length_bytes = parser.drain_length_bytes();
+        let data_bytes = parser.drain_data_bytes();
+        let tag_bytes = parser.drain_tag_bytes();
+
+        assert_eq!(length_bytes.len(), NUM_LENGTH_BYTES);
+        // data_bytes[0] = header byte, data_bytes[1..] = decrypted contents = [0x8e]
+        assert_eq!(data_bytes.len(), 2, "header + 1 content byte");
+        assert_eq!(data_bytes[0], 0x00, "genuine packet header byte");
+        assert_eq!(data_bytes[1], 0x8e, "decrypted content byte");
+        assert_eq!(tag_bytes.len(), NUM_TAG_BYTES);
+        // tag bytes are the raw network bytes (last 16 bytes of known ciphertext)
+        assert_eq!(
+            tag_bytes,
+            &ct[ct.len() - NUM_TAG_BYTES..],
+            "tag matches known ciphertext"
+        );
+    }
+}

--- a/src/bip324/data_read.rs
+++ b/src/bip324/data_read.rs
@@ -96,23 +96,25 @@ impl ProtocolReadParser for DataReadParser {
 
         let (next_state, res) = match state {
             ReceivingPacketLen(mut length_decryptor) => {
-                // TODO: replace unwrap
                 length_decryptor
                     .decrypt_len_part_inplace(&mut data_to_process)
-                    .unwrap();
+                    .expect("decrypt_len_part_inplace cannot fail: to_consume <= remaining_bytes");
 
                 self.output_length_bytes.extend_from_slice(&data_to_process);
 
                 match length_decryptor.try_end() {
                     Ok((length_cipher, packet_len)) => {
-                        // TODO: replace unwrap
                         self.inbound_cipher
                             .reown_length_cipher(length_cipher)
-                            .unwrap();
+                            .expect("reown_length_cipher cannot fail: cipher was extracted in new()");
 
                         if packet_len > MAX_PACKET_SIZE_FOR_ALLOCATION {
-                            // TODO: replace panic
-                            panic!("Packet too big");
+                            self.remaining += to_consume;
+                            let length_decryptor = self
+                                .inbound_cipher
+                                .get_new_length_decryptor()
+                                .expect("length cipher is available after reown");
+                            return (ReceivingPacketLen(length_decryptor), Err(()));
                         }
 
                         let stream_cipher = self
@@ -162,8 +164,8 @@ impl ProtocolReadParser for DataReadParser {
             }
             ReceivingPacketTag(mut expected_tag) => {
                 if data_to_process != expected_tag[..data_to_process.len()] {
-                    // TODO: replace panic
-                    panic!("AEAD tag check fail");
+                    self.remaining += to_consume;
+                    return (ReceivingPacketTag(expected_tag), Err(()));
                 }
                 expected_tag.drain(..data_to_process.len());
 
@@ -187,9 +189,10 @@ impl ProtocolReadParser for DataReadParser {
         };
 
         if res.is_ok() {
-            let _ = data.read(&mut vec![0u8; to_consume]).unwrap();
+            let _ = data
+                .read(&mut vec![0u8; to_consume])
+                .expect("BufReader advance should not fail: to_consume <= buf_ref().len()");
         } else {
-            // TODO: see if you can represent this through typing
             self.remaining += to_consume;
         }
 
@@ -382,10 +385,9 @@ mod tests {
         );
     }
 
-    // 5. Feed correct length + content, then corrupt tag bytes. Verify panic.
+    // 5. Feed correct length + content, then corrupt tag bytes. Verify Err is returned.
     #[test]
-    #[should_panic(expected = "AEAD tag check fail")]
-    fn test_corrupt_tag_panics() {
+    fn test_corrupt_tag_returns_err() {
         let (mut alice_out, bob_in) = make_cipher_pair();
 
         let plaintext = b"tag corruption test";
@@ -399,7 +401,8 @@ mod tests {
 
         let mut parser = DataReadParser::new(vec![], bob_in);
         let mut data = &ciphertext[..];
-        parser.consume(&mut data).unwrap();
+        let result = parser.consume(&mut data);
+        assert!(result.is_err(), "Expected Err on corrupt AEAD tag");
     }
 
     // 6. Use known session keys. Verify the parser decodes the known ciphertext vector.

--- a/src/bip324/data_write.rs
+++ b/src/bip324/data_write.rs
@@ -85,13 +85,14 @@ impl ProtocolWriteParser for DataWriteParser {
                     return (SendingLength(remaining, written), Ok(ProtocolStatus::End));
                 }
 
-                // TODO: replace unwrap
-                let buf = data.prewrite(self.input_length_bytes.len()).unwrap();
+                let buf = match data.prewrite(self.input_length_bytes.len()) {
+                    Ok(buf) => buf,
+                    Err(_) => return (SendingLength(remaining, written), Err(())),
+                };
                 let size = buf.len();
 
                 if size > remaining {
-                    // TODO: replace panic
-                    panic!("Received too many length bytes from the input buffer");
+                    return (SendingLength(remaining, written), Err(()));
                 }
 
                 // Capture plaintext before encrypting
@@ -131,13 +132,14 @@ impl ProtocolWriteParser for DataWriteParser {
                     );
                 }
 
-                // TODO: replace unwrap
-                let buf = data.prewrite(self.input_data_bytes.len()).unwrap();
+                let buf = match data.prewrite(self.input_data_bytes.len()) {
+                    Ok(buf) => buf,
+                    Err(_) => return (SendingPayload(remaining, stream_cipher), Err(())),
+                };
                 let size = buf.len();
 
-                // TODO: replace panic
                 if size > remaining {
-                    panic!("Received too many data bytes from the input buffer");
+                    return (SendingPayload(remaining, stream_cipher), Err(()));
                 }
 
                 buf.copy_from_slice(&self.input_data_bytes[..size]);
@@ -162,13 +164,14 @@ impl ProtocolWriteParser for DataWriteParser {
                     return (SendingTag(tag), Ok(ProtocolStatus::End));
                 }
 
-                // TODO: replace unwrap
-                let buf = data.prewrite(self.input_tag_bytes.len()).unwrap();
+                let buf = match data.prewrite(self.input_tag_bytes.len()) {
+                    Ok(buf) => buf,
+                    Err(_) => return (SendingTag(tag), Err(())),
+                };
                 let size = buf.len();
 
                 if size > tag.len() {
-                    // TODO: replace panic
-                    panic!("Received too many tag bytes from the input buffer");
+                    return (SendingTag(tag), Err(()));
                 }
 
                 // Consume relay tag bytes for pacing, then overwrite with computed tag
@@ -188,8 +191,7 @@ impl ProtocolWriteParser for DataWriteParser {
     }
 
     fn take_state(&mut self) -> Self::State {
-        // TODO: remove unwrap
-        self.state.take().unwrap()
+        self.state.take().expect("DataWriteParser state should not be None")
     }
 
     fn set_state(&mut self, state: Self::State) {

--- a/src/bip324/data_write.rs
+++ b/src/bip324/data_write.rs
@@ -1,0 +1,424 @@
+use crate::cipher::OutboundCipher;
+use crate::external::chacha20_poly1305::ChaCha20Poly1305Stream;
+use crate::protocol::NUM_LENGTH_BYTES;
+use crate::state_machine::{BufWriter, HasFinal, ProtocolStatus, ProtocolWriteParser};
+
+pub enum DataWriteState {
+    SendingLength(usize, Vec<u8>),
+    SendingPayload(usize, ChaCha20Poly1305Stream),
+    SendingTag(Vec<u8>),
+}
+
+impl HasFinal for DataWriteState {
+    /// Always returns false -- packet writing loops forever
+    fn is_final(&self) -> bool {
+        false
+    }
+}
+
+pub struct DataWriteParser {
+    state: Option<DataWriteState>,
+    outbound_cipher: OutboundCipher,
+
+    // Input buffers (pushed by caller)
+    input_length_bytes: Vec<u8>,
+    input_data_bytes: Vec<u8>,
+    input_tag_bytes: Vec<u8>,
+    input_aad: Option<Vec<u8>>,
+}
+
+impl DataWriteParser {
+    pub fn new(outbound_cipher: OutboundCipher) -> Self {
+        Self {
+            state: Some(DataWriteState::SendingLength(NUM_LENGTH_BYTES, vec![])),
+            outbound_cipher,
+            input_length_bytes: vec![],
+            input_data_bytes: vec![],
+            input_tag_bytes: vec![],
+            input_aad: None,
+        }
+    }
+
+    pub fn push_length_bytes(&mut self, bytes: &[u8]) {
+        self.input_length_bytes.extend_from_slice(bytes);
+    }
+
+    pub fn push_data_bytes(&mut self, bytes: &[u8]) {
+        self.input_data_bytes.extend_from_slice(bytes);
+    }
+
+    pub fn push_tag_bytes(&mut self, bytes: &[u8]) {
+        self.input_tag_bytes.extend_from_slice(bytes);
+    }
+
+    pub fn set_aad(&mut self, aad: &[u8]) {
+        self.input_aad = Some(aad.to_vec());
+    }
+
+    pub fn peek_input_length_bytes(&self) -> usize {
+        self.input_length_bytes.len()
+    }
+
+    pub fn peek_input_data_bytes(&self) -> usize {
+        self.input_data_bytes.len()
+    }
+
+    pub fn peek_input_tag_bytes(&self) -> usize {
+        self.input_tag_bytes.len()
+    }
+}
+
+impl ProtocolWriteParser for DataWriteParser {
+    type State = DataWriteState;
+    type Error = ();
+
+    fn transition(
+        &mut self,
+        state: Self::State,
+        data: &mut dyn BufWriter,
+    ) -> (Self::State, Result<ProtocolStatus, Self::Error>) {
+        use DataWriteState::*;
+
+        match state {
+            SendingLength(remaining, written) => {
+                if self.input_length_bytes.is_empty() {
+                    return (SendingLength(remaining, written), Ok(ProtocolStatus::End));
+                }
+
+                // TODO: replace unwrap
+                let buf = data.prewrite(self.input_length_bytes.len()).unwrap();
+                let size = buf.len();
+
+                if size > remaining {
+                    // TODO: replace panic
+                    panic!("Received too many length bytes from the input buffer");
+                }
+
+                // Capture plaintext before encrypting
+                let new_written = [&written[..], &self.input_length_bytes[..size]].concat();
+                buf.copy_from_slice(&self.input_length_bytes[..size]);
+                self.input_length_bytes.drain(..size);
+
+                self.outbound_cipher
+                    .encrypt_len_part_inplace(&mut buf[..size]);
+
+                if size == remaining {
+                    let length_bytes: [u8; 8] =
+                        [new_written, vec![0u8; 5]].concat().try_into().unwrap();
+                    // Add 1 for the header, which is not included in the length
+                    let payload_len = 1 + usize::from_le_bytes(length_bytes);
+                    let stream_cipher = self
+                        .outbound_cipher
+                        .packet_cipher
+                        .start_one_payload_stream_encryption();
+
+                    (
+                        SendingPayload(payload_len, stream_cipher),
+                        Ok(ProtocolStatus::Continue),
+                    )
+                } else {
+                    (
+                        SendingLength(remaining - size, new_written),
+                        Ok(ProtocolStatus::End),
+                    )
+                }
+            }
+            SendingPayload(remaining, mut stream_cipher) => {
+                if self.input_data_bytes.is_empty() {
+                    return (
+                        SendingPayload(remaining, stream_cipher),
+                        Ok(ProtocolStatus::End),
+                    );
+                }
+
+                // TODO: replace unwrap
+                let buf = data.prewrite(self.input_data_bytes.len()).unwrap();
+                let size = buf.len();
+
+                // TODO: replace panic
+                if size > remaining {
+                    panic!("Received too many data bytes from the input buffer");
+                }
+
+                buf.copy_from_slice(&self.input_data_bytes[..size]);
+                self.input_data_bytes.drain(..size);
+
+                stream_cipher.encrypt_and_store_chunk(&mut buf[..size]);
+
+                if size == remaining {
+                    let aad = self.input_aad.take().unwrap_or(vec![]);
+                    let tag = stream_cipher.get_tag(Some(&aad));
+                    self.outbound_cipher.packet_cipher.end_current_stream(&aad);
+                    (SendingTag(tag.to_vec()), Ok(ProtocolStatus::Continue))
+                } else {
+                    (
+                        SendingPayload(remaining - size, stream_cipher),
+                        Ok(ProtocolStatus::End),
+                    )
+                }
+            }
+            SendingTag(mut tag) => {
+                if self.input_tag_bytes.is_empty() {
+                    return (SendingTag(tag), Ok(ProtocolStatus::End));
+                }
+
+                // TODO: replace unwrap
+                let buf = data.prewrite(self.input_tag_bytes.len()).unwrap();
+                let size = buf.len();
+
+                if size > tag.len() {
+                    // TODO: replace panic
+                    panic!("Received too many tag bytes from the input buffer");
+                }
+
+                // Consume relay tag bytes for pacing, then overwrite with computed tag
+                self.input_tag_bytes.drain(..size);
+                buf[..size].copy_from_slice(&tag.drain(0..size).collect::<Vec<_>>());
+
+                if tag.is_empty() {
+                    (
+                        SendingLength(NUM_LENGTH_BYTES, vec![]),
+                        Ok(ProtocolStatus::Continue),
+                    )
+                } else {
+                    (SendingTag(tag), Ok(ProtocolStatus::End))
+                }
+            }
+        }
+    }
+
+    fn take_state(&mut self) -> Self::State {
+        // TODO: remove unwrap
+        self.state.take().unwrap()
+    }
+
+    fn set_state(&mut self, state: Self::State) {
+        self.state = Some(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::str::FromStr;
+    use secp256k1::SecretKey;
+    use secp256k1::ellswift::{ElligatorSwift, ElligatorSwiftParty};
+
+    use crate::bip324::data_read::DataReadParser;
+    use crate::cipher::{CipherSession, InboundCipher, OutboundCipher, SessionKeyMaterial};
+    use crate::protocol::{NUM_TAG_BYTES, Role};
+    use crate::state_machine::{StreamReadParser, StreamWriteParser};
+
+    const MAGIC: [u8; 4] = [0xF9, 0xBE, 0xB4, 0xD9];
+
+    // Returns (alice_outbound [sender], bob_inbound [receiver]) using fixed known keys.
+    fn make_cipher_pair() -> (OutboundCipher, InboundCipher) {
+        let alice = SecretKey::from_str(
+            "61062ea5071d800bbfd59e2e8b53d47d194b095ae5a4df04936b49772ef0d4d7",
+        )
+        .unwrap();
+        let elliswift_alice = ElligatorSwift::from_str("ec0adff257bbfe500c188c80b4fdd640f6b45a482bbc15fc7cef5931deff0aa186f6eb9bba7b85dc4dcc28b28722de1e3d9108b985e2967045668f66098e475b").unwrap();
+        let elliswift_bob = ElligatorSwift::from_str("a4a94dfce69b4a2a0a099313d10f9f7e7d649d60501c9e1d274c300e0d89aafaffffffffffffffffffffffffffffffffffffffffffffffffffffffff8faf88d5").unwrap();
+        let session_keys = SessionKeyMaterial::from_ecdh(
+            elliswift_alice,
+            elliswift_bob,
+            alice,
+            ElligatorSwiftParty::A,
+            MAGIC,
+        )
+        .unwrap();
+        let alice_cipher = CipherSession::new(session_keys.clone(), Role::Initiator);
+        let bob_cipher = CipherSession::new(session_keys, Role::Responder);
+        let (_alice_inbound, alice_outbound) = alice_cipher.into_split();
+        let (bob_inbound, _bob_outbound) = bob_cipher.into_split();
+        (alice_outbound, bob_inbound)
+    }
+
+    // Prepare the three input slices needed by DataWriteParser for one packet.
+    //
+    // Returns (length_bytes, data_bytes, tag_placeholder) where:
+    //   length_bytes: 3-byte little-endian plaintext length (before encryption)
+    //   data_bytes:   genuine header byte (0x00) + plaintext
+    //   tag_placeholder: 16 zero bytes used purely for pacing
+    fn make_packet_input(plaintext: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let len_val = plaintext.len() as u32;
+        let length_bytes = len_val.to_le_bytes()[..NUM_LENGTH_BYTES].to_vec();
+
+        let mut data_bytes = vec![0x00u8]; // genuine header
+        data_bytes.extend_from_slice(plaintext);
+
+        let tag_placeholder = vec![0u8; NUM_TAG_BYTES];
+
+        (length_bytes, data_bytes, tag_placeholder)
+    }
+
+    // Encrypt one packet with DataWriteParser and return the ciphertext.
+    fn encrypt_with_parser(
+        parser: &mut DataWriteParser,
+        plaintext: &[u8],
+        aad: Option<&[u8]>,
+    ) -> Vec<u8> {
+        let (length_bytes, data_bytes, tag_placeholder) = make_packet_input(plaintext);
+        parser.push_length_bytes(&length_bytes);
+        parser.push_data_bytes(&data_bytes);
+        parser.push_tag_bytes(&tag_placeholder);
+        if let Some(a) = aad {
+            parser.set_aad(a);
+        }
+
+        let out_len = NUM_LENGTH_BYTES + data_bytes.len() + NUM_TAG_BYTES;
+        let mut out = vec![0u8; out_len];
+        parser.produce(&mut out.as_mut_slice()).unwrap();
+        out
+    }
+
+    // 1. Push 3 length bytes + header+payload + 16 tag bytes. produce(). Decrypt the output
+    //    with matching InboundCipher. Verify roundtrip.
+    #[test]
+    fn test_encrypt_single_packet() {
+        let (alice_out, mut bob_in) = make_cipher_pair();
+
+        let plaintext = b"hello bip324";
+        let mut parser = DataWriteParser::new(alice_out);
+        let ciphertext = encrypt_with_parser(&mut parser, plaintext, None);
+
+        let packet_len = bob_in.decrypt_packet_len(ciphertext[..NUM_LENGTH_BYTES].try_into().unwrap());
+        let mut ct_body = ciphertext[NUM_LENGTH_BYTES..NUM_LENGTH_BYTES + packet_len].to_vec();
+        let (_pkt_type, msg) = bob_in.decrypt_in_place(&mut ct_body, None).unwrap();
+
+        // msg[0] is the header byte; msg[1..] is plaintext
+        assert_eq!(&msg[1..], plaintext);
+    }
+
+    // 2. Push one byte at a time. step() after each. Verify correct encrypted output.
+    #[test]
+    fn test_encrypt_byte_by_byte() {
+        let (alice_out, mut bob_in) = make_cipher_pair();
+
+        let plaintext = b"incremental";
+        let (length_bytes, data_bytes, tag_placeholder) = make_packet_input(plaintext);
+        let out_len = NUM_LENGTH_BYTES + data_bytes.len() + NUM_TAG_BYTES;
+
+        let mut parser = DataWriteParser::new(alice_out);
+        let mut out = vec![0u8; out_len];
+        let mut out_slice = out.as_mut_slice();
+
+        for &byte in &length_bytes {
+            parser.push_length_bytes(&[byte]);
+            parser.step(&mut out_slice).unwrap();
+        }
+        for &byte in &data_bytes {
+            parser.push_data_bytes(&[byte]);
+            parser.step(&mut out_slice).unwrap();
+        }
+        for &byte in &tag_placeholder {
+            parser.push_tag_bytes(&[byte]);
+            parser.step(&mut out_slice).unwrap();
+        }
+
+        let packet_len = bob_in.decrypt_packet_len(out[..NUM_LENGTH_BYTES].try_into().unwrap());
+        let mut ct_body = out[NUM_LENGTH_BYTES..NUM_LENGTH_BYTES + packet_len].to_vec();
+        let (_pkt_type, msg) = bob_in.decrypt_in_place(&mut ct_body, None).unwrap();
+
+        assert_eq!(&msg[1..], plaintext);
+    }
+
+    // 3. Push two packets' worth of data. Verify both encrypted correctly.
+    #[test]
+    fn test_encrypt_multiple_packets() {
+        let (alice_out, mut bob_in) = make_cipher_pair();
+
+        let msg1 = b"first packet";
+        let msg2 = b"second packet";
+
+        let mut parser = DataWriteParser::new(alice_out);
+
+        let ct1 = encrypt_with_parser(&mut parser, msg1, None);
+        let ct2 = encrypt_with_parser(&mut parser, msg2, None);
+
+        // Decrypt first
+        let len1 = bob_in.decrypt_packet_len(ct1[..NUM_LENGTH_BYTES].try_into().unwrap());
+        let mut body1 = ct1[NUM_LENGTH_BYTES..NUM_LENGTH_BYTES + len1].to_vec();
+        let (_pkt, msg) = bob_in.decrypt_in_place(&mut body1, None).unwrap();
+        assert_eq!(&msg[1..], msg1.as_slice());
+
+        // Decrypt second
+        let len2 = bob_in.decrypt_packet_len(ct2[..NUM_LENGTH_BYTES].try_into().unwrap());
+        let mut body2 = ct2[NUM_LENGTH_BYTES..NUM_LENGTH_BYTES + len2].to_vec();
+        let (_pkt, msg) = bob_in.decrypt_in_place(&mut body2, None).unwrap();
+        assert_eq!(&msg[1..], msg2.as_slice());
+    }
+
+    // 4. Set AAD before first packet. Verify encrypted output decrypts correctly with matching AAD.
+    #[test]
+    fn test_encrypt_with_aad() {
+        let (alice_out, mut bob_in) = make_cipher_pair();
+
+        let garbage_aad: Vec<u8> = vec![0xAA; 32];
+        let plaintext = b"aad packet";
+
+        let mut parser = DataWriteParser::new(alice_out);
+        let ciphertext = encrypt_with_parser(&mut parser, plaintext, Some(&garbage_aad));
+
+        let packet_len = bob_in.decrypt_packet_len(ciphertext[..NUM_LENGTH_BYTES].try_into().unwrap());
+        let mut ct_body = ciphertext[NUM_LENGTH_BYTES..NUM_LENGTH_BYTES + packet_len].to_vec();
+        let (_pkt, msg) = bob_in.decrypt_in_place(&mut ct_body, Some(&garbage_aad)).unwrap();
+
+        assert_eq!(&msg[1..], plaintext);
+    }
+
+    // 5. Push arbitrary tag bytes (not matching computed tag). Verify output uses the parser's
+    //    computed tag (not the input tag bytes).
+    #[test]
+    fn test_tag_replacement() {
+        let (alice_out, mut bob_in) = make_cipher_pair();
+
+        let plaintext = b"tag replace";
+        let (length_bytes, data_bytes, _) = make_packet_input(plaintext);
+
+        // Push 0xFF bytes as the relay tag -- these should be replaced
+        let wrong_tag = vec![0xFFu8; NUM_TAG_BYTES];
+
+        let mut parser = DataWriteParser::new(alice_out);
+        parser.push_length_bytes(&length_bytes);
+        parser.push_data_bytes(&data_bytes);
+        parser.push_tag_bytes(&wrong_tag);
+
+        let out_len = NUM_LENGTH_BYTES + data_bytes.len() + NUM_TAG_BYTES;
+        let mut out = vec![0u8; out_len];
+        parser.produce(&mut out.as_mut_slice()).unwrap();
+
+        // The last 16 bytes should NOT be 0xFF (they are the real computed tag)
+        assert_ne!(
+            &out[out_len - NUM_TAG_BYTES..],
+            wrong_tag.as_slice(),
+            "output tag should be computed AEAD tag, not the pushed bytes"
+        );
+
+        // The real AEAD tag allows correct decryption
+        let packet_len = bob_in.decrypt_packet_len(out[..NUM_LENGTH_BYTES].try_into().unwrap());
+        let mut ct_body = out[NUM_LENGTH_BYTES..NUM_LENGTH_BYTES + packet_len].to_vec();
+        let (_pkt, msg) = bob_in.decrypt_in_place(&mut ct_body, None).unwrap();
+        assert_eq!(&msg[1..], plaintext);
+    }
+
+    // 6. Encrypt with DataWriteParser, decrypt with DataReadParser. Verify plaintext matches.
+    #[test]
+    fn test_roundtrip_with_data_read_parser() {
+        let (alice_out, bob_in) = make_cipher_pair();
+
+        let plaintext = b"roundtrip test";
+
+        let mut write_parser = DataWriteParser::new(alice_out);
+        let ciphertext = encrypt_with_parser(&mut write_parser, plaintext, None);
+
+        let mut read_parser = DataReadParser::new(vec![], bob_in);
+        let mut data = ciphertext.as_slice();
+        read_parser.consume(&mut data).unwrap();
+
+        let data_bytes = read_parser.drain_data_bytes();
+        // data_bytes[0] = header byte, data_bytes[1..] = plaintext
+        assert_eq!(data_bytes[0], 0x00, "genuine packet header byte");
+        assert_eq!(&data_bytes[1..], plaintext);
+    }
+}

--- a/src/bip324/handshake_read.rs
+++ b/src/bip324/handshake_read.rs
@@ -160,6 +160,21 @@ impl HandshakeReadParser {
         self.state.as_ref().is_some_and(|s| s.is_final())
     }
 
+    pub fn is_receiving_key(&self) -> bool {
+        matches!(self.state, Some(HandshakeReadState::ReceivingKey(..)))
+    }
+
+    pub fn is_receiving_garbage(&self) -> bool {
+        matches!(self.state, Some(HandshakeReadState::ReceivingGarbage(_)))
+    }
+
+    pub fn inbound_garbage_terminator(&self) -> Option<&GarbageTerminatorType> {
+        match self.state.as_ref()? {
+            HandshakeReadState::ReceivingGarbage(gt) => Some(gt),
+            _ => None,
+        }
+    }
+
     pub fn take_aad(&mut self) -> Option<AADType> {
         let state = self.state.take()?;
         match state {

--- a/src/bip324/handshake_read.rs
+++ b/src/bip324/handshake_read.rs
@@ -259,8 +259,9 @@ impl ProtocolReadParser for HandshakeReadParser {
                         find_garbage(&self.read_buffer, other_garbage_terminator)
                     {
                         to_consume -= rest.len();
-                        // TODO: replace unwrap
-                        let _ = data.read(&mut vec![0u8; to_consume]).unwrap();
+                        let _ = data
+                            .read(&mut vec![0u8; to_consume])
+                            .expect("BufReader advance should not fail: to_consume <= buf_ref().len()");
 
                         // Remove the final bytes that are not part of the garbage
                         self.read_buffer

--- a/src/bip324/handshake_read.rs
+++ b/src/bip324/handshake_read.rs
@@ -1,0 +1,688 @@
+use std::cmp;
+
+use crate::cipher::{CipherSession, InboundCipher, OutboundCipher};
+use crate::protocol::{
+    AADType, EcdhPoint, GarbageTerminatorType, MagicType, NUM_ELLIGATOR_SWIFT_BYTES,
+    NUM_GARBAGE_CONTENT_LIMIT, NUM_GARBAGE_TERMINATOR_BYTES, Role, find_garbage,
+};
+use crate::state_machine::{BufReader, HasFinal, ProtocolReadParser, ProtocolStatus};
+use crate::BIP324MitmError;
+use BIP324MitmError::*;
+
+#[derive(Debug)]
+pub enum HandshakeReadState {
+    ReceivingKey(EcdhPoint, usize),          // secret_key, remaining_bytes
+    ReceivingGarbage(GarbageTerminatorType), // inbound_garbage_terminator
+    HandshakeDone(AADType),                  // garbage content (AAD)
+}
+
+impl HasFinal for HandshakeReadState {
+    fn is_final(&self) -> bool {
+        matches!(self, Self::HandshakeDone(_))
+    }
+}
+
+pub struct HandshakeReadParser {
+    role: Role,
+    magic: MagicType,
+    state: Option<HandshakeReadState>,
+    read_buffer: Vec<u8>,
+    other_key: Option<[u8; NUM_ELLIGATOR_SWIFT_BYTES]>,
+
+    // Tracks our own ellswift bytes so the MITM layer can read them at any time
+    own_ellswift_bytes: [u8; NUM_ELLIGATOR_SWIFT_BYTES],
+
+    // Output buffers -- drained by caller after each step()
+    output_key_bytes: Vec<u8>,
+    output_garbage_bytes: Vec<u8>,
+    output_terminator_bytes: Vec<u8>,
+    key_eof: bool,
+    garbage_eof: bool,
+
+    // Derived protocol data
+    cipher_session: Option<CipherSession>,
+    outbound_garbage_terminator: Option<GarbageTerminatorType>,
+}
+
+impl HandshakeReadParser {
+    pub fn new(role: Role, magic: MagicType, secret_key: EcdhPoint) -> Self {
+        let own_ellswift_bytes = secret_key.elligator_swift.to_array();
+        Self {
+            role,
+            magic,
+            state: Some(HandshakeReadState::ReceivingKey(
+                secret_key,
+                NUM_ELLIGATOR_SWIFT_BYTES,
+            )),
+            read_buffer: vec![],
+            other_key: None,
+            own_ellswift_bytes,
+            output_key_bytes: vec![],
+            output_garbage_bytes: vec![],
+            output_terminator_bytes: vec![],
+            key_eof: false,
+            garbage_eof: false,
+            cipher_session: None,
+            outbound_garbage_terminator: None,
+        }
+    }
+
+    fn on_share_received(
+        &mut self,
+        point: EcdhPoint,
+    ) -> Result<GarbageTerminatorType, (EcdhPoint, BIP324MitmError)> {
+        let Some(other_key) = &self.other_key else {
+            return Err((
+                point,
+                IllegalState("on_share_received called with empty other_key".to_string()),
+            ));
+        };
+        let cipher = CipherSession::new_from_shares(self.magic, self.role, point, other_key)
+            .map_err(|(point, _)| (point, KeyGenerationError))?;
+        let inbound_garbage_terminator = cipher.inbound_garbage_terminator;
+        let outbound_garbage_terminator = cipher.outbound_garbage_terminator;
+
+        self.cipher_session = Some(cipher);
+        self.outbound_garbage_terminator = Some(outbound_garbage_terminator);
+
+        Ok(inbound_garbage_terminator)
+    }
+
+    pub fn set_ecdh_point(
+        &mut self,
+        point: EcdhPoint,
+    ) -> Result<(), (EcdhPoint, BIP324MitmError)> {
+        use HandshakeReadState::*;
+
+        if self.state.as_ref().is_some_and(|s| s.is_final()) {
+            return Err((
+                point,
+                IllegalState("Can't change key. Handshake is already done".to_string()),
+            ));
+        }
+
+        self.own_ellswift_bytes = point.elligator_swift.to_array();
+
+        match self.state.take() {
+            Some(ReceivingKey(_old_point, remaining)) => {
+                self.state = Some(ReceivingKey(point, remaining));
+                Ok(())
+            }
+            Some(ReceivingGarbage(_old_garbage_terminator)) => {
+                let inbound_garbage_terminator = self
+                    .on_share_received(point)?;
+                self.state = Some(ReceivingGarbage(inbound_garbage_terminator));
+                Ok(())
+            }
+            state => {
+                self.state = state;
+                Err((
+                    point,
+                    IllegalState("Can't change key in this state".to_string()),
+                ))
+            }
+        }
+    }
+
+    pub fn drain_key_bytes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output_key_bytes)
+    }
+
+    pub fn drain_garbage_bytes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output_garbage_bytes)
+    }
+
+    pub fn drain_terminator_bytes(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output_terminator_bytes)
+    }
+
+    pub fn is_key_eof(&self) -> bool {
+        self.key_eof
+    }
+
+    pub fn is_garbage_eof(&self) -> bool {
+        self.garbage_eof
+    }
+
+    pub fn take_ciphers(&mut self) -> Option<(InboundCipher, OutboundCipher)> {
+        self.cipher_session.take().map(|c| c.into_split())
+    }
+
+    pub fn outbound_garbage_terminator(&self) -> Option<&GarbageTerminatorType> {
+        self.outbound_garbage_terminator.as_ref()
+    }
+
+    pub fn elligator_swift_bytes(&self) -> [u8; NUM_ELLIGATOR_SWIFT_BYTES] {
+        self.own_ellswift_bytes
+    }
+
+    pub fn is_handshake_done(&self) -> bool {
+        self.state.as_ref().is_some_and(|s| s.is_final())
+    }
+
+    pub fn take_aad(&mut self) -> Option<AADType> {
+        let state = self.state.take()?;
+        match state {
+            HandshakeReadState::HandshakeDone(aad) => {
+                self.state = Some(HandshakeReadState::HandshakeDone(vec![]));
+                Some(aad)
+            }
+            _ => {
+                self.state = Some(state);
+                None
+            }
+        }
+    }
+}
+
+impl ProtocolReadParser for HandshakeReadParser {
+    type State = HandshakeReadState;
+    type Error = BIP324MitmError;
+
+    fn transition(
+        &mut self,
+        state: Self::State,
+        data: &mut dyn BufReader,
+    ) -> (Self::State, Result<ProtocolStatus, Self::Error>) {
+        use HandshakeReadState::*;
+
+        match state {
+            ReceivingKey(point, mut remaining) => {
+                let mut key_buf = vec![0u8; remaining];
+                let size = match data.read(&mut key_buf) {
+                    Ok(size) => size,
+                    Err(err) => {
+                        return (
+                            ReceivingKey(point, remaining),
+                            Err(BIP324MitmError::ReadError(err)),
+                        );
+                    }
+                };
+                remaining -= size;
+
+                self.read_buffer.extend_from_slice(&key_buf[..size]);
+                self.output_key_bytes.extend_from_slice(&key_buf[..size]);
+
+                if remaining == 0 {
+                    self.key_eof = true;
+
+                    let mut other_key = [0u8; NUM_ELLIGATOR_SWIFT_BYTES];
+                    other_key.copy_from_slice(&std::mem::take(&mut self.read_buffer));
+                    self.other_key = Some(other_key);
+
+                    let inbound_garbage_terminator = match self.on_share_received(point) {
+                        Ok(ret) => ret,
+                        Err((point, err)) => {
+                            return (ReceivingKey(point, remaining), Err(err));
+                        }
+                    };
+
+                    (
+                        ReceivingGarbage(inbound_garbage_terminator),
+                        Ok(ProtocolStatus::Continue),
+                    )
+                } else {
+                    (ReceivingKey(point, remaining), Ok(ProtocolStatus::End))
+                }
+            }
+
+            // This uses a peek-then-read strategy
+            state @ ReceivingGarbage(other_garbage_terminator) => {
+                // The length under which we don't know if an array of data is a garbage terminator
+                let insurance_len = other_garbage_terminator.len() - 1;
+                let prevlen = self.read_buffer.len();
+
+                // When the read buffer has data that can still be part of the garbage terminator
+                let mut found = {
+                    let data_buf = data.buf_ref();
+                    let mut to_consume = cmp::min(data_buf.len(), insurance_len);
+
+                    self.read_buffer.extend_from_slice(&data_buf[..to_consume]);
+
+                    // If terminator found, actually consume the buffer
+                    if let Some((_garbage, rest)) =
+                        find_garbage(&self.read_buffer, other_garbage_terminator)
+                    {
+                        to_consume -= rest.len();
+                        // TODO: replace unwrap
+                        let _ = data.read(&mut vec![0u8; to_consume]).unwrap();
+
+                        // Remove the final bytes that are not part of the garbage
+                        self.read_buffer
+                            .resize(self.read_buffer.len() - rest.len(), 0u8);
+
+                        true
+                    // If terminator not found, restore the read buffer
+                    } else {
+                        self.read_buffer
+                            .resize(self.read_buffer.len() - to_consume, 0u8);
+
+                        false
+                    }
+                };
+
+                // If still not found, look for the garbage terminator in the new data
+                found = if !found {
+                    let data_buf = data.buf_ref();
+                    let res = find_garbage(data_buf, other_garbage_terminator);
+
+                    let (to_consume, found) = if let Some((garbage, _rest)) = res {
+                        (garbage.len(), true)
+                    } else {
+                        (data_buf.len(), false)
+                    };
+
+                    let mut buf = vec![0u8; to_consume];
+                    data.read_exact(&mut buf).unwrap();
+                    self.read_buffer.extend(buf);
+
+                    found
+                } else {
+                    found
+                };
+
+                if self.read_buffer.len() > NUM_GARBAGE_CONTENT_LIMIT + NUM_GARBAGE_TERMINATOR_BYTES
+                {
+                    return (state, Err(GarbageLimitExceededError));
+                }
+
+                if found {
+                    // Here, we expect self.read_buffer to contain the garbage, including the
+                    // terminator
+
+                    let currlen = self.read_buffer.len();
+                    let garbage_len = currlen - other_garbage_terminator.len();
+                    let lhs = cmp::max(prevlen, insurance_len) - insurance_len;
+                    let new_range = lhs..garbage_len;
+
+                    // Copy slices to avoid multiple borrows of self
+                    let garbage_chunk = self.read_buffer[new_range].to_vec();
+                    self.output_garbage_bytes.extend_from_slice(&garbage_chunk);
+                    self.garbage_eof = true;
+
+                    let term_chunk = self.read_buffer[garbage_len..].to_vec();
+                    self.output_terminator_bytes.extend_from_slice(&term_chunk);
+
+                    let aad: Vec<_> = self.read_buffer.splice(..garbage_len, []).collect();
+                    self.read_buffer.clear();
+
+                    (HandshakeDone(aad), Ok(ProtocolStatus::End))
+                } else {
+                    let currlen = self.read_buffer.len();
+                    let lhs = cmp::max(prevlen, insurance_len) - insurance_len;
+                    let rhs = cmp::max(currlen, insurance_len) - insurance_len;
+                    // The range of data that wasn't relayed and we're sure it's garbage, and is not part of the terminator
+                    let new_range = lhs..rhs;
+
+                    let garbage_chunk = self.read_buffer[new_range].to_vec();
+                    self.output_garbage_bytes.extend_from_slice(&garbage_chunk);
+
+                    (state, Ok(ProtocolStatus::End))
+                }
+            }
+
+            state @ HandshakeDone(_) => (state, Ok(ProtocolStatus::End)),
+        }
+    }
+
+    fn take_state(&mut self) -> Self::State {
+        self.state.take().unwrap()
+    }
+
+    fn set_state(&mut self, state: Self::State) {
+        self.state = Some(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+    use secp256k1::rand::{CryptoRng, RngCore};
+    use secp256k1::rand::rngs::mock::StepRng;
+
+    use crate::protocol::NUM_GARBAGE_TERMINATOR_BYTES;
+    use crate::state_machine::StreamReadParser;
+
+    const DEFAULT_MAGIC: MagicType = [0xF9, 0xBE, 0xB4, 0xD9];
+
+    // Mirrors HANDSHAKE_PARAMS1 from lib.rs
+    #[allow(dead_code)]
+    struct TestHandshakeParams {
+        server_seed: u64,
+        server_key: [u8; NUM_ELLIGATOR_SWIFT_BYTES],
+        server_garbage_terminator: [u8; NUM_GARBAGE_TERMINATOR_BYTES],
+        client_key: [u8; NUM_ELLIGATOR_SWIFT_BYTES],
+        client_garbage_terminator: [u8; NUM_GARBAGE_TERMINATOR_BYTES],
+        initiator_l: [u8; 32],
+        initiator_p: [u8; 32],
+        responder_l: [u8; 32],
+        responder_p: [u8; 32],
+    }
+
+    const HANDSHAKE_PARAMS1: TestHandshakeParams = TestHandshakeParams {
+        server_seed: 32890322278,
+        server_key: hex!(
+            "6a34b0f8757abbd31934ce6375857b06000d1a4528274eaec46c6e11a243366dcb14d23c315b7305fb4bd7c11ddc515785061f2a9402c867f2550a7e8e5496ca"
+        ),
+        server_garbage_terminator: hex!("7064cc9fe99282b77afbe58925e2cf2b"),
+        client_key: hex!(
+            "61a5de62da81aec5967d511fec1f08f98e9c1108bffaaf304b5b31876bec2cbc2d20736f19f93b3f3fd7b9bbf7d1306da07d13218b90fae8c22276846848ad0c"
+        ),
+        client_garbage_terminator: hex!("e2b91cf5fae994f1e81c361ce00d110d"),
+        initiator_l: hex!("ab7e81f5d65d97c015f71bab4506dd93f6dfca7b182f30cd27896afbc4855c3a"),
+        initiator_p: hex!("48d22cd6fb02fe202ddc668d2dcade20a9c5500566acb804d18806b5cac44595"),
+        responder_l: hex!("42e672f539b95ec5950bb2d97b45a3cb9ac4b58244b05b35fb8ed1315aab8e6d"),
+        responder_p: hex!("0c71faf552c2883beebfb82b557593a60caa0f38749bb393dd5bb656ed768a01"),
+    };
+
+    struct TestRng(StepRng);
+    impl CryptoRng for TestRng {}
+
+    impl TestRng {
+        fn new(initial: u64, increment: u64) -> Self {
+            Self(StepRng::new(initial, increment))
+        }
+    }
+
+    impl RngCore for TestRng {
+        fn next_u32(&mut self) -> u32 {
+            self.0.next_u32()
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            self.0.next_u64()
+        }
+
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            self.0.fill_bytes(dest)
+        }
+
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), secp256k1::rand::Error> {
+            self.0.try_fill_bytes(dest)
+        }
+    }
+
+    fn insecurerng(seed: u64) -> TestRng {
+        TestRng::new(seed, seed / 2 + 1)
+    }
+
+    fn secret_key_bytes_from_rng<Rng: RngCore + CryptoRng>(rng: &mut Rng) -> [u8; 32] {
+        let mut buf = [0u8; 32];
+        RngCore::fill_bytes(rng, &mut buf);
+        buf
+    }
+
+    fn parser_from_rng<Rng: RngCore + CryptoRng>(
+        role: Role,
+        rng: &mut Rng,
+    ) -> HandshakeReadParser {
+        let bytes = secret_key_bytes_from_rng(rng);
+        let point = crate::key_from_secret_bytes(bytes).unwrap();
+        HandshakeReadParser::new(role, DEFAULT_MAGIC, point)
+    }
+
+    fn parser_from_seed(role: Role, seed: u64) -> HandshakeReadParser {
+        let mut rng = insecurerng(seed);
+        parser_from_rng(role, &mut rng)
+    }
+
+    // 1. Feed 64 key bytes at once. Verify drain_key_bytes() returns all 64.
+    //    Verify state transitions to ReceivingGarbage.
+    #[test]
+    fn test_parse_key_complete() {
+        let mut parser = parser_from_seed(Role::Responder, 1111);
+
+        let key_bytes = [0x42u8; NUM_ELLIGATOR_SWIFT_BYTES];
+        let mut data = &key_bytes[..];
+        parser.step(&mut data).unwrap();
+
+        let drained = parser.drain_key_bytes();
+        assert_eq!(drained.len(), NUM_ELLIGATOR_SWIFT_BYTES);
+        assert_eq!(drained, key_bytes);
+        assert!(parser.is_key_eof());
+        assert!(matches!(
+            parser.state,
+            Some(HandshakeReadState::ReceivingGarbage(_))
+        ));
+    }
+
+    // 2. Feed 1 byte at a time (64 iterations). After each step(), verify
+    //    drain_key_bytes() returns 1 byte. After 64, verify state is ReceivingGarbage.
+    #[test]
+    fn test_parse_key_byte_by_byte() {
+        let mut parser = parser_from_seed(Role::Responder, 2222);
+
+        let key_bytes = [0x7Eu8; NUM_ELLIGATOR_SWIFT_BYTES];
+        for i in 0..NUM_ELLIGATOR_SWIFT_BYTES {
+            let mut data = &key_bytes[i..i + 1];
+            parser.step(&mut data).unwrap();
+            let drained = parser.drain_key_bytes();
+            assert_eq!(drained.len(), 1, "Expected 1 byte at step {i}");
+            assert_eq!(drained[0], key_bytes[i]);
+        }
+
+        assert!(parser.is_key_eof());
+        assert!(matches!(
+            parser.state,
+            Some(HandshakeReadState::ReceivingGarbage(_))
+        ));
+    }
+
+    // 3. Feed 74 bytes. Verify key output is 64 bytes, parser in ReceivingGarbage,
+    //    extra 10 bytes consumed as potential garbage.
+    #[test]
+    fn test_parse_key_overflow() {
+        let mut parser = parser_from_seed(Role::Responder, 3333);
+
+        let all_bytes = [0x5Au8; NUM_ELLIGATOR_SWIFT_BYTES + 10];
+        let mut data = &all_bytes[..];
+        // step() reads exactly remaining (64) bytes from the key phase; then Continue loops.
+        // consume() runs until End.
+        parser.consume(&mut data).unwrap();
+
+        let drained = parser.drain_key_bytes();
+        assert_eq!(drained.len(), NUM_ELLIGATOR_SWIFT_BYTES);
+        assert!(parser.is_key_eof());
+        assert!(matches!(
+            parser.state,
+            Some(HandshakeReadState::ReceivingGarbage(_))
+        ));
+    }
+
+    // 4. Feed HANDSHAKE_PARAMS1.client_key as the peer's key. Verify take_ciphers()
+    //    returns Some((inbound, outbound)). Confirm derived key material matches
+    //    expected vectors.
+    #[test]
+    fn test_cipher_session_derivation() {
+        let TestHandshakeParams {
+            server_seed,
+            client_key,
+            client_garbage_terminator,
+            initiator_l,
+            initiator_p,
+            responder_l,
+            responder_p,
+            ..
+        } = HANDSHAKE_PARAMS1;
+
+        let mut parser = parser_from_seed(Role::Responder, server_seed);
+
+        let mut data = &client_key[..];
+        parser.consume(&mut data).unwrap();
+
+        let (inbound, outbound) = parser.take_ciphers().expect("Expected ciphers after key phase");
+
+        assert_eq!(
+            inbound.length_cipher.unwrap().key_bytes,
+            initiator_l,
+            "inbound length key mismatch"
+        );
+        assert_eq!(
+            inbound.packet_cipher.key_bytes, initiator_p,
+            "inbound packet key mismatch"
+        );
+        assert_eq!(
+            outbound.length_cipher.key_bytes, responder_l,
+            "outbound length key mismatch"
+        );
+        assert_eq!(
+            outbound.packet_cipher.key_bytes, responder_p,
+            "outbound packet key mismatch"
+        );
+
+        // Also verify the inbound garbage terminator equals client's expected value
+        let Some(HandshakeReadState::ReceivingGarbage(inbound_term)) = parser.state.as_ref()
+        else {
+            panic!("Expected ReceivingGarbage state");
+        };
+        assert_eq!(*inbound_term, client_garbage_terminator);
+    }
+
+    // 5. Feed key + garbage + terminator. Verify drain_garbage_bytes() returns the
+    //    garbage, is_handshake_done() is true.
+    #[test]
+    fn test_garbage_with_terminator() {
+        let TestHandshakeParams {
+            server_seed,
+            client_key,
+            client_garbage_terminator,
+            ..
+        } = HANDSHAKE_PARAMS1;
+
+        let mut parser = parser_from_seed(Role::Responder, server_seed);
+
+        let garbage = [0xAAu8; 20];
+        let mut input = Vec::new();
+        input.extend_from_slice(&client_key);
+        input.extend_from_slice(&garbage);
+        input.extend_from_slice(&client_garbage_terminator);
+
+        let mut data = &input[..];
+        parser.consume(&mut data).unwrap();
+
+        let drained_garbage = parser.drain_garbage_bytes();
+        let drained_term = parser.drain_terminator_bytes();
+
+        assert_eq!(drained_garbage, garbage, "Garbage content mismatch");
+        assert_eq!(
+            drained_term.len(),
+            NUM_GARBAGE_TERMINATOR_BYTES,
+            "Terminator length mismatch"
+        );
+        assert_eq!(drained_term, client_garbage_terminator, "Terminator mismatch");
+        assert!(parser.is_garbage_eof());
+        assert!(parser.is_handshake_done());
+    }
+
+    // 6. Feed key + 4112 bytes of garbage. Verify GarbageLimitExceededError.
+    #[test]
+    fn test_garbage_limit_exceeded() {
+        let TestHandshakeParams {
+            server_seed,
+            client_key,
+            ..
+        } = HANDSHAKE_PARAMS1;
+
+        let mut parser = parser_from_seed(Role::Responder, server_seed);
+
+        let mut data = &client_key[..];
+        parser.consume(&mut data).unwrap();
+
+        // Feed 4112 bytes of garbage (exceeds 4095 + 16 = 4111 limit)
+        let garbage = vec![0xBBu8; 4112];
+        let mut gref = &garbage[..];
+        let result = parser.consume(&mut gref);
+
+        assert!(
+            matches!(result, Err(BIP324MitmError::GarbageLimitExceededError)),
+            "Expected GarbageLimitExceededError"
+        );
+    }
+
+    // 7. Set new EcdhPoint after receiving some key bytes (still in ReceivingKey).
+    //    Verify the new point is used for ECDH.
+    #[test]
+    fn test_set_ecdh_point_during_key() {
+        let TestHandshakeParams {
+            server_seed,
+            client_key,
+            initiator_l,
+            initiator_p,
+            responder_l,
+            responder_p,
+            ..
+        } = HANDSHAKE_PARAMS1;
+
+        // Start with an arbitrary initial key
+        let mut parser = parser_from_seed(Role::Responder, 7777);
+
+        // Feed a partial key (30 bytes)
+        let mut partial = &client_key[..30];
+        parser.step(&mut partial).unwrap();
+        assert!(matches!(
+            parser.state,
+            Some(HandshakeReadState::ReceivingKey(..))
+        ));
+
+        // Replace the key with the "real" server key (from server_seed)
+        let server_point = {
+            let mut rng = insecurerng(server_seed);
+            let bytes = secret_key_bytes_from_rng(&mut rng);
+            crate::key_from_secret_bytes(bytes).unwrap()
+        };
+        parser.set_ecdh_point(server_point).unwrap();
+
+        // Feed the remaining 34 bytes
+        let mut rest = &client_key[30..];
+        parser.consume(&mut rest).unwrap();
+
+        // Now take ciphers — they should be derived from the real server key + client_key
+        let (inbound, outbound) = parser.take_ciphers().expect("Expected ciphers");
+        assert_eq!(inbound.length_cipher.unwrap().key_bytes, initiator_l);
+        assert_eq!(inbound.packet_cipher.key_bytes, initiator_p);
+        assert_eq!(outbound.length_cipher.key_bytes, responder_l);
+        assert_eq!(outbound.packet_cipher.key_bytes, responder_p);
+    }
+
+    // 8. Set new EcdhPoint after full key received (in ReceivingGarbage).
+    //    Verify take_ciphers() returns ciphers derived from the new point.
+    #[test]
+    fn test_set_ecdh_point_after_key() {
+        let TestHandshakeParams {
+            server_seed,
+            client_key,
+            initiator_l,
+            initiator_p,
+            responder_l,
+            responder_p,
+            ..
+        } = HANDSHAKE_PARAMS1;
+
+        // Start with an arbitrary initial key
+        let mut parser = parser_from_seed(Role::Responder, 8888);
+
+        // Feed full client key — parser moves to ReceivingGarbage with wrong ciphers
+        let mut data = &client_key[..];
+        parser.consume(&mut data).unwrap();
+        assert!(matches!(
+            parser.state,
+            Some(HandshakeReadState::ReceivingGarbage(_))
+        ));
+
+        // Replace with the correct server key
+        let server_point = {
+            let mut rng = insecurerng(server_seed);
+            let bytes = secret_key_bytes_from_rng(&mut rng);
+            crate::key_from_secret_bytes(bytes).unwrap()
+        };
+        parser.set_ecdh_point(server_point).unwrap();
+
+        // take_ciphers() should now give ciphers from the real server key + client_key
+        let (inbound, outbound) = parser.take_ciphers().expect("Expected ciphers");
+        assert_eq!(inbound.length_cipher.unwrap().key_bytes, initiator_l);
+        assert_eq!(inbound.packet_cipher.key_bytes, initiator_p);
+        assert_eq!(outbound.length_cipher.key_bytes, responder_l);
+        assert_eq!(outbound.packet_cipher.key_bytes, responder_p);
+    }
+}

--- a/src/bip324/handshake_write.rs
+++ b/src/bip324/handshake_write.rs
@@ -61,8 +61,24 @@ impl HandshakeWriteParser {
         self.outbound_cipher.take()
     }
 
+    pub fn has_outbound_cipher(&self) -> bool {
+        self.outbound_cipher.is_some()
+    }
+
     pub fn is_done(&self) -> bool {
         self.state.as_ref().is_some_and(|s| s.is_final())
+    }
+
+    pub fn is_sending_key(&self) -> bool {
+        matches!(self.state, Some(HandshakeWriteState::SendingKey))
+    }
+
+    pub fn is_sending_garbage(&self) -> bool {
+        matches!(self.state, Some(HandshakeWriteState::SendingGarbage))
+    }
+
+    pub fn is_sending_terminator(&self) -> bool {
+        matches!(self.state, Some(HandshakeWriteState::SendingGarbageTerminator))
     }
 }
 

--- a/src/bip324/handshake_write.rs
+++ b/src/bip324/handshake_write.rs
@@ -1,0 +1,312 @@
+use std::cmp;
+
+use crate::cipher::OutboundCipher;
+use crate::state_machine::{BufWriter, HasFinal, ProtocolStatus, ProtocolWriteParser};
+
+pub enum HandshakeWriteState {
+    SendingKey,
+    SendingGarbage,
+    SendingGarbageTerminator,
+    Done,
+}
+
+impl HasFinal for HandshakeWriteState {
+    fn is_final(&self) -> bool {
+        matches!(self, Self::Done)
+    }
+}
+
+pub struct HandshakeWriteParser {
+    state: Option<HandshakeWriteState>,
+    key_bytes: Vec<u8>,
+    garbage_bytes: Vec<u8>,
+    garbage_eof: bool,
+    terminator_bytes: Vec<u8>,
+    outbound_cipher: Option<OutboundCipher>,
+}
+
+impl HandshakeWriteParser {
+    pub fn new(key_bytes: Vec<u8>) -> Self {
+        Self {
+            state: Some(HandshakeWriteState::SendingKey),
+            key_bytes,
+            garbage_bytes: vec![],
+            garbage_eof: false,
+            terminator_bytes: vec![],
+            outbound_cipher: None,
+        }
+    }
+
+    pub fn set_key_bytes(&mut self, key: Vec<u8>) {
+        self.key_bytes = key;
+    }
+
+    pub fn push_garbage_bytes(&mut self, bytes: &[u8]) {
+        self.garbage_bytes.extend_from_slice(bytes);
+    }
+
+    pub fn set_garbage_eof(&mut self) {
+        self.garbage_eof = true;
+    }
+
+    pub fn set_terminator(&mut self, terminator: &[u8]) {
+        self.terminator_bytes = terminator.to_vec();
+    }
+
+    pub fn set_outbound_cipher(&mut self, cipher: OutboundCipher) {
+        self.outbound_cipher = Some(cipher);
+    }
+
+    pub fn take_outbound_cipher(&mut self) -> Option<OutboundCipher> {
+        self.outbound_cipher.take()
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.state.as_ref().is_some_and(|s| s.is_final())
+    }
+}
+
+impl ProtocolWriteParser for HandshakeWriteParser {
+    type State = HandshakeWriteState;
+    type Error = ();
+
+    fn transition(
+        &mut self,
+        state: Self::State,
+        data: &mut dyn BufWriter,
+    ) -> (Self::State, Result<ProtocolStatus, Self::Error>) {
+        use HandshakeWriteState::*;
+
+        match state {
+            state @ SendingKey => {
+                let size = cmp::min(data.remaining(), self.key_bytes.len());
+                data.write_all(&self.key_bytes[..size]).unwrap();
+                self.key_bytes.splice(..size, []);
+
+                if self.key_bytes.is_empty() {
+                    (SendingGarbage, Ok(ProtocolStatus::Continue))
+                } else {
+                    (state, Ok(ProtocolStatus::End))
+                }
+            }
+            state @ SendingGarbage => {
+                let size = cmp::min(data.remaining(), self.garbage_bytes.len());
+                data.write_all(&self.garbage_bytes[..size]).unwrap();
+                self.garbage_bytes.splice(..size, []);
+
+                if self.garbage_bytes.is_empty() && self.garbage_eof {
+                    (SendingGarbageTerminator, Ok(ProtocolStatus::Continue))
+                } else {
+                    (state, Ok(ProtocolStatus::End))
+                }
+            }
+            state @ SendingGarbageTerminator => {
+                let size = cmp::min(data.remaining(), self.terminator_bytes.len());
+                data.write_all(&self.terminator_bytes[..size]).unwrap();
+                self.terminator_bytes.splice(..size, []);
+
+                if self.terminator_bytes.is_empty() {
+                    (Done, Ok(ProtocolStatus::End))
+                } else {
+                    (state, Ok(ProtocolStatus::End))
+                }
+            }
+            state @ Done => (state, Ok(ProtocolStatus::End)),
+        }
+    }
+
+    fn take_state(&mut self) -> Self::State {
+        self.state.take().unwrap()
+    }
+
+    fn set_state(&mut self, state: Self::State) {
+        self.state = Some(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::NUM_ELLIGATOR_SWIFT_BYTES;
+    use crate::state_machine::{ProtocolStatus, StreamWriteParser};
+
+    const KEY_LEN: usize = NUM_ELLIGATOR_SWIFT_BYTES;
+    const TERMINATOR_LEN: usize = 16;
+
+    // 1. Create parser with 64 key bytes. produce() with 64-byte buffer. Verify all key bytes written.
+    #[test]
+    fn test_write_key_complete() {
+        let expected_key = vec![0xABu8; KEY_LEN];
+        let mut parser = HandshakeWriteParser::new(expected_key.clone());
+
+        let mut buf = vec![0u8; KEY_LEN];
+        let mut write_slice = buf.as_mut_slice();
+        parser.step(&mut write_slice).unwrap();
+
+        assert_eq!(buf, expected_key);
+    }
+
+    // 2. Create parser with 64 key bytes. step() with 10-byte buffer repeatedly. Verify correct chunking.
+    #[test]
+    fn test_write_key_chunked() {
+        let expected_key: Vec<u8> = (0u8..KEY_LEN as u8).collect();
+        let mut parser = HandshakeWriteParser::new(expected_key.clone());
+
+        let mut all_output = Vec::new();
+        let chunk_size = 10;
+        let mut remaining = KEY_LEN;
+        while remaining > 0 {
+            let this_chunk = chunk_size.min(remaining);
+            let mut chunk = vec![0u8; this_chunk];
+            {
+                let mut s = chunk.as_mut_slice();
+                parser.step(&mut s).unwrap();
+            }
+            all_output.extend_from_slice(&chunk);
+            remaining -= this_chunk;
+        }
+
+        assert_eq!(all_output, expected_key);
+    }
+
+    // 3. Full handshake: key || garbage || terminator in one produce() call.
+    #[test]
+    fn test_write_full_handshake() {
+        let key = vec![0x01u8; KEY_LEN];
+        let garbage = vec![0xFFu8; 20];
+        let terminator = vec![0xAAu8; TERMINATOR_LEN];
+
+        let mut parser = HandshakeWriteParser::new(key.clone());
+        parser.push_garbage_bytes(&garbage);
+        parser.set_garbage_eof();
+        parser.set_terminator(&terminator);
+
+        let mut buf = vec![0u8; KEY_LEN + 20 + TERMINATOR_LEN];
+        {
+            let mut s = buf.as_mut_slice();
+            parser.produce(&mut s).unwrap();
+        }
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&key);
+        expected.extend_from_slice(&garbage);
+        expected.extend_from_slice(&terminator);
+
+        assert_eq!(buf, expected);
+        assert!(parser.is_done());
+    }
+
+    // 4. No garbage: output is key || terminator.
+    #[test]
+    fn test_write_no_garbage() {
+        let key = vec![0x02u8; KEY_LEN];
+        let terminator = vec![0xBBu8; TERMINATOR_LEN];
+
+        let mut parser = HandshakeWriteParser::new(key.clone());
+        parser.set_garbage_eof();
+        parser.set_terminator(&terminator);
+
+        let mut buf = vec![0u8; KEY_LEN + TERMINATOR_LEN];
+        {
+            let mut s = buf.as_mut_slice();
+            parser.produce(&mut s).unwrap();
+        }
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&key);
+        expected.extend_from_slice(&terminator);
+
+        assert_eq!(buf, expected);
+        assert!(parser.is_done());
+    }
+
+    // 5. Change key bytes before any writing. Verify new key is written.
+    #[test]
+    fn test_set_key_bytes() {
+        let original_key = vec![0x01u8; KEY_LEN];
+        let new_key = vec![0x02u8; KEY_LEN];
+
+        let mut parser = HandshakeWriteParser::new(original_key);
+        parser.set_key_bytes(new_key.clone());
+
+        let mut buf = vec![0u8; KEY_LEN];
+        {
+            let mut s = buf.as_mut_slice();
+            parser.step(&mut s).unwrap();
+        }
+
+        assert_eq!(buf, new_key);
+    }
+
+    // 6. Push garbage in small chunks, calling step() after each. Verify output accumulates correctly.
+    #[test]
+    fn test_pacing_garbage() {
+        let key = vec![0x03u8; KEY_LEN];
+        let mut parser = HandshakeWriteParser::new(key.clone());
+
+        // Consume the key phase first
+        let mut key_out = vec![0u8; KEY_LEN];
+        {
+            let mut s = key_out.as_mut_slice();
+            let result = parser.step(&mut s).unwrap();
+            assert!(matches!(result, ProtocolStatus::Continue));
+        }
+        assert_eq!(key_out, key);
+        assert!(matches!(
+            parser.state,
+            Some(HandshakeWriteState::SendingGarbage)
+        ));
+
+        // Push garbage in 3 chunks of 5 bytes and step after each
+        let full_garbage = vec![0x77u8; 15];
+        let mut all_garbage_out = Vec::new();
+
+        for chunk in full_garbage.chunks(5) {
+            parser.push_garbage_bytes(chunk);
+            let mut gbuf = vec![0u8; 5];
+            {
+                let mut s = gbuf.as_mut_slice();
+                parser.step(&mut s).unwrap();
+            }
+            all_garbage_out.extend_from_slice(&gbuf);
+        }
+
+        assert_eq!(all_garbage_out, full_garbage);
+        assert!(matches!(
+            parser.state,
+            Some(HandshakeWriteState::SendingGarbage)
+        ));
+    }
+
+    // 7. Push garbage without setting EOF. Verify parser stays in SendingGarbage and returns End.
+    #[test]
+    fn test_no_output_when_no_garbage_eof() {
+        let key = vec![0x04u8; KEY_LEN];
+        let mut parser = HandshakeWriteParser::new(key);
+
+        // Consume key phase
+        let mut key_buf = vec![0u8; KEY_LEN];
+        {
+            let mut s = key_buf.as_mut_slice();
+            parser.step(&mut s).unwrap();
+        }
+
+        // Push garbage but do NOT set EOF
+        parser.push_garbage_bytes(&[0xCCu8; 10]);
+
+        // Run step with a large buffer
+        let mut buf = vec![0u8; 100];
+        let result = {
+            let mut s = buf.as_mut_slice();
+            parser.step(&mut s).unwrap()
+        };
+
+        // Should return End (no transition to SendingGarbageTerminator)
+        assert!(matches!(result, ProtocolStatus::End));
+        // Parser should still be in SendingGarbage
+        assert!(matches!(
+            parser.state,
+            Some(HandshakeWriteState::SendingGarbage)
+        ));
+    }
+}

--- a/src/bip324/mod.rs
+++ b/src/bip324/mod.rs
@@ -1,3 +1,5 @@
 pub mod handshake_read;
+pub mod handshake_write;
 
 pub use handshake_read::{HandshakeReadParser, HandshakeReadState};
+pub use handshake_write::{HandshakeWriteParser, HandshakeWriteState};

--- a/src/bip324/mod.rs
+++ b/src/bip324/mod.rs
@@ -7,3 +7,207 @@ pub use data_read::{DataReadParser, DataReadState};
 pub use data_write::{DataWriteParser, DataWriteState};
 pub use handshake_read::{HandshakeReadParser, HandshakeReadState};
 pub use handshake_write::{HandshakeWriteParser, HandshakeWriteState};
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+    use secp256k1::ellswift::ElligatorSwiftParty;
+
+    use super::{DataReadParser, DataWriteParser, HandshakeReadParser};
+    use crate::cipher::{InboundCipher, OutboundCipher, SessionKeyMaterial};
+    use crate::key_from_secret_bytes;
+    use crate::protocol::{MAINNET_MAGIC, NUM_LENGTH_BYTES, NUM_TAG_BYTES, Role};
+    use crate::state_machine::{StreamReadParser, StreamWriteParser};
+
+    const MAGIC: [u8; 4] = MAINNET_MAGIC;
+
+    // Fixed deterministic keys used across all integration tests.
+    const ALICE_SECRET: [u8; 32] =
+        hex!("61062ea5071d800bbfd59e2e8b53d47d194b095ae5a4df04936b49772ef0d4d7");
+    const BOB_SECRET: [u8; 32] =
+        hex!("6f312890ec83bbb26798abaadd574684a53e74ccef7953b790fcc29409080246");
+
+    // Complete a BIP-324 handshake using only HandshakeReadParser objects -- no relay or MITM types.
+    // Returns (alice_inbound, alice_outbound, bob_inbound, bob_outbound).
+    fn complete_handshake() -> (InboundCipher, OutboundCipher, InboundCipher, OutboundCipher) {
+        let alice_key = key_from_secret_bytes(ALICE_SECRET).unwrap();
+        let bob_key = key_from_secret_bytes(BOB_SECRET).unwrap();
+
+        let bob_wire_key = bob_key.elligator_swift.to_array().to_vec();
+        let alice_wire_key = alice_key.elligator_swift.to_array().to_vec();
+
+        let mut alice_parser = HandshakeReadParser::new(Role::Initiator, MAGIC, alice_key);
+        let mut bob_parser = HandshakeReadParser::new(Role::Responder, MAGIC, bob_key);
+
+        // Exchange public keys
+        alice_parser.consume(&mut bob_wire_key.as_slice()).unwrap();
+        bob_parser.consume(&mut alice_wire_key.as_slice()).unwrap();
+
+        // Exchange garbage terminators (no garbage content -- empty garbage is valid)
+        let alice_outbound_term = alice_parser.outbound_garbage_terminator().unwrap().to_vec();
+        let bob_outbound_term = bob_parser.outbound_garbage_terminator().unwrap().to_vec();
+
+        alice_parser.consume(&mut bob_outbound_term.as_slice()).unwrap();
+        bob_parser.consume(&mut alice_outbound_term.as_slice()).unwrap();
+
+        assert!(alice_parser.is_handshake_done());
+        assert!(bob_parser.is_handshake_done());
+
+        let (alice_inbound, alice_outbound) = alice_parser.take_ciphers().unwrap();
+        let (bob_inbound, bob_outbound) = bob_parser.take_ciphers().unwrap();
+
+        (alice_inbound, alice_outbound, bob_inbound, bob_outbound)
+    }
+
+    // Encrypt one plaintext packet with DataWriteParser and return the ciphertext.
+    fn encrypt_packet(parser: &mut DataWriteParser, plaintext: &[u8]) -> Vec<u8> {
+        let len_val = plaintext.len() as u32;
+        let length_bytes = len_val.to_le_bytes()[..NUM_LENGTH_BYTES].to_vec();
+        let mut data_bytes = vec![0x00u8]; // genuine header byte
+        data_bytes.extend_from_slice(plaintext);
+        let tag_placeholder = vec![0u8; NUM_TAG_BYTES]; // pacing only; parser overwrites with real AEAD tag
+
+        parser.push_length_bytes(&length_bytes);
+        parser.push_data_bytes(&data_bytes);
+        parser.push_tag_bytes(&tag_placeholder);
+
+        let out_len = NUM_LENGTH_BYTES + data_bytes.len() + NUM_TAG_BYTES;
+        let mut out = vec![0u8; out_len];
+        parser.produce(&mut out.as_mut_slice()).unwrap();
+        out
+    }
+
+    // 1. Both sides exchange keys via HandshakeReadParser and independently derive a matching
+    //    session ID. Verifies the ECDH is symmetric and the parsers report completion.
+    #[test]
+    fn test_handshake_roundtrip() {
+        let alice_key_for_session = key_from_secret_bytes(ALICE_SECRET).unwrap();
+        let bob_key_for_session = key_from_secret_bytes(BOB_SECRET).unwrap();
+        let alice_key_for_parser = key_from_secret_bytes(ALICE_SECRET).unwrap();
+        let bob_key_for_parser = key_from_secret_bytes(BOB_SECRET).unwrap();
+
+        // Compute session IDs from both sides independently using raw ECDH
+        let alice_session = SessionKeyMaterial::from_ecdh(
+            alice_key_for_session.elligator_swift,
+            bob_key_for_session.elligator_swift,
+            alice_key_for_session.secret_key,
+            ElligatorSwiftParty::A,
+            MAGIC,
+        )
+        .unwrap();
+        let bob_session = SessionKeyMaterial::from_ecdh(
+            alice_key_for_session.elligator_swift, // ElligatorSwift is Copy
+            bob_key_for_session.elligator_swift,
+            bob_key_for_session.secret_key,
+            ElligatorSwiftParty::B,
+            MAGIC,
+        )
+        .unwrap();
+
+        assert_eq!(
+            alice_session.session_id, bob_session.session_id,
+            "Session IDs must match from both sides"
+        );
+
+        // Both sides complete the handshake via parsers alone
+        let bob_wire_key = bob_key_for_parser.elligator_swift.to_array().to_vec();
+        let alice_wire_key = alice_key_for_parser.elligator_swift.to_array().to_vec();
+
+        let mut alice_parser =
+            HandshakeReadParser::new(Role::Initiator, MAGIC, alice_key_for_parser);
+        let mut bob_parser = HandshakeReadParser::new(Role::Responder, MAGIC, bob_key_for_parser);
+
+        alice_parser.consume(&mut bob_wire_key.as_slice()).unwrap();
+        bob_parser.consume(&mut alice_wire_key.as_slice()).unwrap();
+
+        let alice_outbound_term = alice_parser.outbound_garbage_terminator().unwrap().to_vec();
+        let bob_outbound_term = bob_parser.outbound_garbage_terminator().unwrap().to_vec();
+
+        alice_parser.consume(&mut bob_outbound_term.as_slice()).unwrap();
+        bob_parser.consume(&mut alice_outbound_term.as_slice()).unwrap();
+
+        assert!(alice_parser.is_handshake_done(), "Alice handshake must complete");
+        assert!(bob_parser.is_handshake_done(), "Bob handshake must complete");
+    }
+
+    // 2. Complete handshake bidirectionally, then verify a data roundtrip:
+    //    Side A encrypts with DataWriteParser → Side B decrypts with DataReadParser → matches plaintext.
+    #[test]
+    fn test_full_protocol_flow() {
+        let (_alice_inbound, alice_outbound, bob_inbound, _bob_outbound) = complete_handshake();
+
+        let plaintext = b"hello from alice to bob";
+
+        let mut encrypt_parser = DataWriteParser::new(alice_outbound);
+        let ciphertext = encrypt_packet(&mut encrypt_parser, plaintext);
+
+        let mut decrypt_parser = DataReadParser::new(vec![], bob_inbound);
+        decrypt_parser.consume(&mut ciphertext.as_slice()).unwrap();
+
+        let decrypted = decrypt_parser.drain_data_bytes();
+        assert_eq!(decrypted[0], 0x00, "Expected genuine header byte");
+        assert_eq!(&decrypted[1..], plaintext, "Decrypted payload must match original plaintext");
+    }
+
+    // 3. Demonstrate that the protocol parsers work entirely standalone:
+    //    no FakePeerRelay, no Rc<RefCell<>>, and no MitmImpersonatorLeg are involved.
+    //    This is the primary proof that the bip324 module separation was successful.
+    #[test]
+    fn test_protocol_parsers_standalone() {
+        // No relay, Rc, or MITM types anywhere in this test.
+        let alice_key = key_from_secret_bytes(ALICE_SECRET).unwrap();
+        let bob_key = key_from_secret_bytes(BOB_SECRET).unwrap();
+
+        let bob_wire_key = bob_key.elligator_swift.to_array().to_vec();
+        let alice_wire_key = alice_key.elligator_swift.to_array().to_vec();
+
+        let mut alice_hs = HandshakeReadParser::new(Role::Initiator, MAGIC, alice_key);
+        let mut bob_hs = HandshakeReadParser::new(Role::Responder, MAGIC, bob_key);
+
+        // Key exchange
+        alice_hs.consume(&mut bob_wire_key.as_slice()).unwrap();
+        bob_hs.consume(&mut alice_wire_key.as_slice()).unwrap();
+
+        // Terminator exchange
+        let alice_term = alice_hs.outbound_garbage_terminator().unwrap().to_vec();
+        let bob_term = bob_hs.outbound_garbage_terminator().unwrap().to_vec();
+        alice_hs.consume(&mut bob_term.as_slice()).unwrap();
+        bob_hs.consume(&mut alice_term.as_slice()).unwrap();
+
+        let (_, alice_outbound) = alice_hs.take_ciphers().unwrap();
+        let (bob_inbound, _) = bob_hs.take_ciphers().unwrap();
+
+        // Alice → Bob data transfer using only pure parser objects
+        let msg = b"standalone parsers work without any MITM infrastructure";
+        let mut write = DataWriteParser::new(alice_outbound);
+        let ct = encrypt_packet(&mut write, msg);
+
+        let mut read = DataReadParser::new(vec![], bob_inbound);
+        read.consume(&mut ct.as_slice()).unwrap();
+
+        let plain = read.drain_data_bytes();
+        assert_eq!(&plain[1..], msg);
+    }
+
+    // 4. Multiple consecutive packets through DataWriteParser → DataReadParser.
+    //    Verifies that cipher key ratcheting works correctly across packet boundaries.
+    #[test]
+    fn test_multiple_packets_roundtrip() {
+        let (_alice_inbound, alice_outbound, bob_inbound, _bob_outbound) = complete_handshake();
+
+        let messages: &[&[u8]] = &[b"first message", b"second message", b"third message"];
+
+        let mut write_parser = DataWriteParser::new(alice_outbound);
+        let ciphertexts: Vec<Vec<u8>> = messages
+            .iter()
+            .map(|msg| encrypt_packet(&mut write_parser, msg))
+            .collect();
+
+        let mut read_parser = DataReadParser::new(vec![], bob_inbound);
+        for (i, (ct, expected)) in ciphertexts.iter().zip(messages.iter()).enumerate() {
+            read_parser.consume(&mut ct.as_slice()).unwrap();
+            let decrypted = read_parser.drain_data_bytes();
+            assert_eq!(&decrypted[1..], *expected, "Packet {i} roundtrip failed");
+        }
+    }
+}

--- a/src/bip324/mod.rs
+++ b/src/bip324/mod.rs
@@ -1,0 +1,3 @@
+pub mod handshake_read;
+
+pub use handshake_read::{HandshakeReadParser, HandshakeReadState};

--- a/src/bip324/mod.rs
+++ b/src/bip324/mod.rs
@@ -1,5 +1,7 @@
+pub mod data_read;
 pub mod handshake_read;
 pub mod handshake_write;
 
+pub use data_read::{DataReadParser, DataReadState};
 pub use handshake_read::{HandshakeReadParser, HandshakeReadState};
 pub use handshake_write::{HandshakeWriteParser, HandshakeWriteState};

--- a/src/bip324/mod.rs
+++ b/src/bip324/mod.rs
@@ -1,7 +1,9 @@
 pub mod data_read;
+pub mod data_write;
 pub mod handshake_read;
 pub mod handshake_write;
 
 pub use data_read::{DataReadParser, DataReadState};
+pub use data_write::{DataWriteParser, DataWriteState};
 pub use handshake_read::{HandshakeReadParser, HandshakeReadState};
 pub use handshake_write::{HandshakeWriteParser, HandshakeWriteState};

--- a/src/cipher.rs
+++ b/src/cipher.rs
@@ -557,11 +557,9 @@ fn generate_session_keys_ecdh(
 
     let skm =
         SessionKeyMaterial::from_ecdh(initiator_ellswift, responder_ellswift, secret, party, magic)
-            .map_err(|_| "Error creating the shared key".to_string());
+            .map_err(|_| "Error creating the shared key".to_string())?;
 
-    let skm = skm.unwrap();
-
-    Ok(skm) // TODO: remove me
+    Ok(skm)
 }
 
 /// Manages cipher state for a BIP-324 encrypted connection.
@@ -643,8 +641,10 @@ impl CipherSession {
 
     /// Split the session into separate inbound and outbound ciphers.
     pub fn into_split(self) -> (InboundCipher, OutboundCipher) {
-        // TODO: replace unwrap
-        (self.inbound.unwrap(), self.outbound.unwrap())
+        (
+            self.inbound.expect("inbound cipher was consumed before into_split"),
+            self.outbound.expect("outbound cipher was consumed before into_split"),
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bip324;
 pub mod cipher;
 pub mod external;
 mod fmt_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,6 @@ use crate::state_machine::{
     StreamReadParser, StreamWriteParser,
 };
 
-// Maximum packet size for automatic allocation.
-// Bitcoin Core's MAX_PROTOCOL_MESSAGE_LENGTH is 4,000,000 bytes (~4 MiB).
-// 14 extra bytes are for the BIP-324 header byte and 13 serialization header bytes (message type).
-const MAX_PACKET_SIZE_FOR_ALLOCATION: usize = 4000014;
-
 #[derive(Error, Debug)]
 pub enum BIP324MitmError {
     #[error("IO Read error")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,13 +200,14 @@ impl ProtocolReadParser for MitmImpersonatorLeg {
 
         match state {
             Handshake(mut reader_leg) => {
-                // TODO: replace unwrap
                 if let Err(err) = reader_leg.consume(data) {
                     return (Handshake(reader_leg), Err(err));
                 }
 
                 if reader_leg.is_final() {
-                    let (new_reader_leg, outbound_cipher) = reader_leg.next_phase().unwrap();
+                    let (new_reader_leg, outbound_cipher) = reader_leg
+                        .next_phase()
+                        .expect("next_phase() returns Some when is_final() is true");
                     // Route outbound cipher to the writer's handshake parser
                     if let Some(WriterLegState::Handshake(ref mut writer_leg)) =
                         self.writer_leg_state
@@ -219,8 +220,7 @@ impl ProtocolReadParser for MitmImpersonatorLeg {
                 }
             }
             Data(mut reader_leg) => {
-                // TODO: replace unwrap
-                reader_leg.consume(data).unwrap();
+                reader_leg.consume(data).expect("data reader step should not fail");
 
                 (Data(reader_leg), Ok(ProtocolStatus::End))
             }
@@ -249,12 +249,13 @@ impl ProtocolWriteParser for MitmImpersonatorLeg {
 
         match state {
             Handshake(mut writer_leg) => {
-                // TODO: replace unwrap
-                writer_leg.produce(data).unwrap();
+                writer_leg.produce(data).expect("handshake writer step should not fail");
 
                 if writer_leg.is_final() {
                     if writer_leg.parser.has_outbound_cipher() {
-                        let new_writer_leg = writer_leg.next_phase().unwrap();
+                        let new_writer_leg = writer_leg
+                            .next_phase()
+                            .expect("next_phase() returns Some when has_outbound_cipher() is true");
                         (Data(new_writer_leg), Ok(ProtocolStatus::End))
                     } else {
                         // Cipher not yet forwarded from reader; stay in handshake
@@ -265,8 +266,7 @@ impl ProtocolWriteParser for MitmImpersonatorLeg {
                 }
             }
             Data(mut writer_leg) => {
-                // TODO: replace unwrap
-                writer_leg.produce(data).unwrap();
+                writer_leg.produce(data).expect("data writer step should not fail");
 
                 (Data(writer_leg), Ok(ProtocolStatus::End))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod state_machine;
 use std::cell::RefCell;
 use std::cmp;
 use std::error::Error;
+use std::io;
+use std::io::Write;
 use std::rc::Rc;
 
 use secp256k1::ellswift::ElligatorSwift;
@@ -16,12 +18,11 @@ use secp256k1::rand::{CryptoRng, RngCore};
 use secp256k1::{PublicKey, Secp256k1, SecretKey};
 use thiserror::Error;
 
-use crate::cipher::{CipherSession, InboundCipher, LengthDecryptor, OutboundCipher};
-use crate::external::chacha20_poly1305::ChaCha20Poly1305Stream;
+use crate::bip324::{DataReadParser, DataWriteParser, HandshakeReadParser, HandshakeWriteParser};
+use crate::cipher::{InboundCipher, OutboundCipher};
 use crate::protocol::{
     AADType, EcdhPoint, GarbageTerminatorType, MAINNET_MAGIC, MagicType, NUM_ELLIGATOR_SWIFT_BYTES,
-    NUM_GARBAGE_CONTENT_LIMIT, NUM_GARBAGE_TERMINATOR_BYTES, NUM_LENGTH_BYTES, NUM_SECRET_BYTES,
-    NUM_TAG_BYTES, REGTEST_MAGIC, Role, TESTNET_MAGIC, TagType, find_garbage,
+    NUM_SECRET_BYTES, REGTEST_MAGIC, Role, TESTNET_MAGIC,
 };
 use crate::relay::{FakePeerRelay, FakePeerRelayReader, FakePeerRelayWriter};
 use crate::state_machine::{
@@ -54,68 +55,38 @@ pub enum BIP324MitmError {
 
 use BIP324MitmError::*;
 
-pub enum LegWriterState {
-    SendingLength(usize, Vec<u8>),
-    SendingPayload(usize, ChaCha20Poly1305Stream),
-    SendingTag(Vec<u8>),
+// A BufWriter wrapper that limits how many bytes can be written per step().
+// Used to implement relay-channel pacing in handshake writers.
+struct LimitedWriter<'a> {
+    inner: &'a mut dyn BufWriter,
+    limit: usize,
 }
 
-impl LegWriterState {
-    fn new() -> Self {
-        Self::SendingLength(NUM_LENGTH_BYTES, vec![])
+impl Write for LimitedWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let to_write = cmp::min(buf.len(), self.limit);
+        if to_write == 0 {
+            return Ok(0);
+        }
+        let written = self.inner.write(&buf[..to_write])?;
+        self.limit -= written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
     }
 }
 
-impl HasFinal for LegWriterState {
-    /// Always returns false
-    fn is_final(&self) -> bool {
-        false
+impl BufWriter for LimitedWriter<'_> {
+    fn remaining(&self) -> usize {
+        cmp::min(self.limit, self.inner.remaining())
     }
-}
 
-#[derive(PartialEq)]
-pub enum HandshakeRelayPeerState {
-    SendingKey,
-    SendingGarbage,
-    SendingGarbageTerminator,
-    HandshakeDone,
-}
-
-impl HandshakeRelayPeerState {
-    fn new() -> Self {
-        Self::SendingKey
-    }
-}
-
-impl HasFinal for HandshakeRelayPeerState {
-    fn is_final(&self) -> bool {
-        matches!(self, Self::HandshakeDone)
-    }
-}
-
-#[derive(Debug)]
-pub enum HandshakeBIP324State {
-    ReceivingKey(EcdhPoint, usize),
-    ReceivingGarbage(GarbageTerminatorType),
-    HandshakeDone(AADType),
-}
-
-impl HasFinal for HandshakeBIP324State {
-    fn is_final(&self) -> bool {
-        matches!(self, Self::HandshakeDone(_))
-    }
-}
-
-pub enum DataBIP324State {
-    ReceivingPacketLen(LengthDecryptor),
-    ReceivingPacketContent(ChaCha20Poly1305Stream),
-    ReceivingPacketTag(TagType),
-}
-
-impl HasFinal for DataBIP324State {
-    /// Always returns false
-    fn is_final(&self) -> bool {
-        false
+    fn prewrite(&mut self, amount: usize) -> io::Result<&mut [u8]> {
+        let size = cmp::min(amount, self.remaining());
+        self.limit -= size;
+        self.inner.prewrite(size)
     }
 }
 
@@ -157,12 +128,8 @@ impl MitmImpersonatorLeg {
         relay_out: Rc<RefCell<dyn FakePeerRelayWriter>>,
         secret_key: EcdhPoint,
     ) -> Self {
-        // We know the fake server's public key, so we can already prepare it for sending
-        let mut key_to_send_vec = vec![];
-        key_to_send_vec.extend_from_slice(&secret_key.elligator_swift.to_array());
-
-        let key_to_send = Rc::new(RefCell::new(key_to_send_vec));
-        let cipher = Rc::new(RefCell::new(None));
+        let key_bytes = secret_key.elligator_swift.to_array().to_vec();
+        let key_to_send = Rc::new(RefCell::new(key_bytes.clone()));
         let garbage_terminator_to_send = Rc::new(RefCell::new(vec![]));
 
         let reader_leg = MitmHandshakeImpersonatorLegReader::new(
@@ -171,13 +138,11 @@ impl MitmImpersonatorLeg {
             relay_out,
             secret_key,
             Rc::clone(&key_to_send),
-            Rc::clone(&cipher),
             Rc::clone(&garbage_terminator_to_send),
         );
         let writer_leg = MitmHandshakeImpersonatorLegWriter::new(
             relay_in,
-            key_to_send,
-            cipher,
+            key_bytes,
             garbage_terminator_to_send,
         );
 
@@ -209,8 +174,16 @@ impl MitmImpersonatorLeg {
         &mut self,
         secret: [u8; NUM_SECRET_BYTES],
     ) -> Result<(), ([u8; NUM_SECRET_BYTES], BIP324MitmError)> {
-        match &mut self.reader_leg_state {
-            Some(ReaderLegState::Handshake(reader_leg)) => reader_leg.set_secret(secret),
+        match (&mut self.reader_leg_state, &mut self.writer_leg_state) {
+            (
+                Some(ReaderLegState::Handshake(reader_leg)),
+                Some(WriterLegState::Handshake(writer_leg)),
+            ) => {
+                reader_leg.set_secret(secret)?;
+                let new_key = reader_leg.key_to_send.borrow().clone();
+                writer_leg.parser.set_key_bytes(new_key);
+                Ok(())
+            }
             _ => Err((
                 secret,
                 IllegalState("Invalid state for set_secret".to_string()),
@@ -238,7 +211,13 @@ impl ProtocolReadParser for MitmImpersonatorLeg {
                 }
 
                 if reader_leg.is_final() {
-                    let new_reader_leg = reader_leg.next_phase().unwrap();
+                    let (new_reader_leg, outbound_cipher) = reader_leg.next_phase().unwrap();
+                    // Route outbound cipher to the writer's handshake parser
+                    if let Some(WriterLegState::Handshake(ref mut writer_leg)) =
+                        self.writer_leg_state
+                    {
+                        writer_leg.parser.set_outbound_cipher(outbound_cipher);
+                    }
                     (Data(new_reader_leg), Ok(ProtocolStatus::End))
                 } else {
                     (Handshake(reader_leg), Ok(ProtocolStatus::End))
@@ -279,8 +258,13 @@ impl ProtocolWriteParser for MitmImpersonatorLeg {
                 writer_leg.produce(data).unwrap();
 
                 if writer_leg.is_final() {
-                    let new_writer_leg = writer_leg.next_phase().unwrap();
-                    (Data(new_writer_leg), Ok(ProtocolStatus::End))
+                    if writer_leg.parser.has_outbound_cipher() {
+                        let new_writer_leg = writer_leg.next_phase().unwrap();
+                        (Data(new_writer_leg), Ok(ProtocolStatus::End))
+                    } else {
+                        // Cipher not yet forwarded from reader; stay in handshake
+                        (Handshake(writer_leg), Ok(ProtocolStatus::End))
+                    }
                 } else {
                     (Handshake(writer_leg), Ok(ProtocolStatus::End))
                 }
@@ -304,18 +288,9 @@ impl ProtocolWriteParser for MitmImpersonatorLeg {
 }
 
 pub struct MitmHandshakeImpersonatorLegReader {
-    role: Role,
-    magic: MagicType,
-    state: Option<HandshakeBIP324State>,
-
+    pub parser: HandshakeReadParser,
     relay_out: Rc<RefCell<dyn FakePeerRelayWriter>>,
-
-    other_key: Option<[u8; NUM_ELLIGATOR_SWIFT_BYTES]>,
-
-    read_buffer: Vec<u8>,
-
-    key_to_send: Rc<RefCell<Vec<u8>>>,
-    cipher: Rc<RefCell<Option<CipherSession>>>,
+    pub key_to_send: Rc<RefCell<Vec<u8>>>,
     garbage_terminator_to_send: Rc<RefCell<Vec<u8>>>,
 }
 
@@ -326,55 +301,23 @@ impl MitmHandshakeImpersonatorLegReader {
         relay_out: Rc<RefCell<dyn FakePeerRelayWriter>>,
         secret_key: EcdhPoint,
         key_to_send: Rc<RefCell<Vec<u8>>>,
-        cipher: Rc<RefCell<Option<CipherSession>>>,
         garbage_terminator_to_send: Rc<RefCell<Vec<u8>>>,
     ) -> Self {
+        let parser = HandshakeReadParser::new(role, magic, secret_key);
         Self {
-            role,
-            magic,
-            state: Some(HandshakeBIP324State::ReceivingKey(
-                secret_key,
-                NUM_ELLIGATOR_SWIFT_BYTES,
-            )),
+            parser,
+            relay_out,
             key_to_send,
             garbage_terminator_to_send,
-            relay_out,
-            other_key: None,
-            read_buffer: vec![],
-            cipher,
         }
-    }
-
-    fn on_share_received(
-        &mut self,
-        point: EcdhPoint,
-    ) -> Result<GarbageTerminatorType, (EcdhPoint, BIP324MitmError)> {
-        let Some(other_key) = &self.other_key else {
-            return Err((
-                point,
-                IllegalState("on_share_received called with empty other_key".to_string()),
-            ));
-        };
-        let cipher = CipherSession::new_from_shares(self.magic, self.role, point, other_key)
-            .map_err(|(point, _)| (point, KeyGenerationError))?;
-        let inbound_garbage_terminator = cipher.inbound_garbage_terminator;
-        let outbound_garbage_terminator = cipher.outbound_garbage_terminator;
-
-        self.cipher.replace(Some(cipher));
-        self.garbage_terminator_to_send
-            .replace(outbound_garbage_terminator.to_vec());
-
-        Ok(inbound_garbage_terminator)
     }
 
     pub fn set_secret(
         &mut self,
         secret: [u8; NUM_SECRET_BYTES],
     ) -> Result<(), ([u8; NUM_SECRET_BYTES], BIP324MitmError)> {
-        use HandshakeBIP324State::*;
-
         if self.key_to_send.borrow().len() < NUM_ELLIGATOR_SWIFT_BYTES
-            || self.state.as_ref().unwrap().is_final()
+            || self.parser.is_handshake_done()
         {
             return Err((
                 secret,
@@ -390,370 +333,190 @@ impl MitmHandshakeImpersonatorLegReader {
                 IllegalState("Can't generate EC scalar from secret key bytes".to_string()),
             )
         })?;
-        let mut key_to_send = vec![];
-        key_to_send.extend_from_slice(&secret_key.elligator_swift.to_array());
 
-        self.key_to_send.replace(key_to_send);
-        match self.state.take() {
-            Some(ReceivingKey(_old_point, remaining)) => {
-                self.state = Some(ReceivingKey(secret_key, remaining));
-            }
-            Some(ReceivingGarbage(_old_other_garbage_terminator)) => {
-                let inbound_garbage_terminator = self
-                    .on_share_received(secret_key)
-                    .map_err(|(_, err)| (secret, err))?;
+        let new_key = secret_key.elligator_swift.to_array().to_vec();
+        self.key_to_send.replace(new_key);
 
-                self.state = Some(ReceivingGarbage(inbound_garbage_terminator));
-            }
-            state => {
-                panic!("Can't change secret for state: {state:?}")
-            }
-        }
+        self.parser
+            .set_ecdh_point(secret_key)
+            .map_err(|(_, err)| (secret, err))?;
 
         Ok(())
     }
 
     pub fn is_final(&self) -> bool {
-        if let Some(state) = &self.state {
-            state.is_final()
-        } else {
-            false
-        }
+        self.parser.is_handshake_done()
     }
 
-    pub fn next_phase(self) -> Option<MitmImpersonatorLegReader> {
-        let Some(HandshakeBIP324State::HandshakeDone(aad)) = self.state else {
+    pub fn is_receiving_key(&self) -> bool {
+        self.parser.is_receiving_key()
+    }
+
+    pub fn is_receiving_garbage(&self) -> bool {
+        self.parser.is_receiving_garbage()
+    }
+
+    pub fn inbound_garbage_terminator(&self) -> Option<&GarbageTerminatorType> {
+        self.parser.inbound_garbage_terminator()
+    }
+
+    pub fn next_phase(mut self) -> Option<(MitmImpersonatorLegReader, OutboundCipher)> {
+        if !self.parser.is_handshake_done() {
             return None;
-        };
-
-        // TODO: replace unwrap
-        let inbound_cipher = self
-            .cipher
-            .borrow_mut()
-            .as_mut()
-            .unwrap()
-            .consume_inbound()
-            .unwrap();
-
-        Some(MitmImpersonatorLegReader::new(
-            aad,
-            self.relay_out,
-            inbound_cipher,
-        ))
+        }
+        let aad = self.parser.take_aad().unwrap_or_default();
+        let (inbound_cipher, outbound_cipher) = self.parser.take_ciphers()?;
+        let reader = MitmImpersonatorLegReader::new(aad, self.relay_out, inbound_cipher);
+        Some((reader, outbound_cipher))
     }
 }
 
-impl ProtocolReadParser for MitmHandshakeImpersonatorLegReader {
-    type State = HandshakeBIP324State;
+impl StreamReadParser for MitmHandshakeImpersonatorLegReader {
     type Error = BIP324MitmError;
 
-    fn transition(
-        &mut self,
-        state: Self::State,
-        data: &mut dyn BufReader,
-    ) -> (Self::State, Result<ProtocolStatus, Self::Error>) {
-        use HandshakeBIP324State::*;
+    fn step(&mut self, data: &mut dyn BufReader) -> Result<ProtocolStatus, Self::Error> {
+        let status = self.parser.step(data)?;
 
-        match state {
-            ReceivingKey(point, mut remaining) => {
-                let mut key_buf = vec![0u8; remaining];
-                let size = match data.read(&mut key_buf) {
-                    Ok(size) => size,
-                    Err(err) => {
-                        return (
-                            ReceivingKey(point, remaining),
-                            Err(BIP324MitmError::ReadError(err)),
-                        );
-                    }
-                };
-                remaining -= size;
-
-                self.read_buffer.extend_from_slice(&key_buf[..size]);
-                // TODO: replace unwrap
-                self.relay_out
-                    .borrow_mut()
-                    .write_key(&key_buf[..size])
-                    .map_err(|_| "Error writing key to relay")
-                    .unwrap();
-
-                if remaining == 0 {
-                    self.relay_out.borrow_mut().set_eof_key();
-
-                    let mut other_key = [0u8; NUM_ELLIGATOR_SWIFT_BYTES];
-                    other_key.copy_from_slice(&std::mem::take(&mut self.read_buffer));
-                    self.other_key = Some(other_key);
-
-                    let inbound_garbage_terminator = match self.on_share_received(point) {
-                        Ok(ret) => ret,
-                        Err((point, err)) => {
-                            return (ReceivingKey(point, remaining), Err(err));
-                        }
-                    };
-
-                    (
-                        ReceivingGarbage(inbound_garbage_terminator),
-                        Ok(ProtocolStatus::Continue),
-                    )
-                } else {
-                    (ReceivingKey(point, remaining), Ok(ProtocolStatus::End))
-                }
-            }
-            // This uses a peek-then-read strategy
-            state @ ReceivingGarbage(other_garbage_terminator) => {
-                // The length under which we don't know if an array of data is a garbage terminator
-                let insurance_len = other_garbage_terminator.len() - 1;
-                let prevlen = self.read_buffer.len();
-                let mut relay_out = self.relay_out.borrow_mut();
-
-                // When the read buffer has data that can still be part of the garbage terminator
-                let mut found = {
-                    let data_buf = data.buf_ref();
-                    let mut to_consume = cmp::min(data_buf.len(), insurance_len);
-
-                    self.read_buffer.extend_from_slice(&data_buf[..to_consume]);
-
-                    // If terminator found, actually consume the buffer
-                    if let Some((_garbage, rest)) =
-                        find_garbage(&self.read_buffer, other_garbage_terminator)
-                    {
-                        to_consume -= rest.len();
-                        // TODO: replace unwrap
-                        let _ = data.read(&mut vec![0u8; to_consume]).unwrap();
-
-                        // Remove the final bytes that are not part of the garbage
-                        self.read_buffer
-                            .resize(self.read_buffer.len() - rest.len(), 0u8);
-
-                        true
-                    // If terminator not found, restore the read buffer
-                    } else {
-                        self.read_buffer
-                            .resize(self.read_buffer.len() - to_consume, 0u8);
-
-                        false
-                    }
-                };
-
-                // If still not found, look for the garbage terminator in the new data
-                found = if !found {
-                    let data_buf = data.buf_ref();
-                    let res = find_garbage(data_buf, other_garbage_terminator);
-
-                    let (to_consume, found) = if let Some((garbage, _rest)) = res {
-                        (garbage.len(), true)
-                    } else {
-                        (data_buf.len(), false)
-                    };
-
-                    let mut buf = vec![0u8; to_consume];
-                    data.read_exact(&mut buf).unwrap();
-                    self.read_buffer.extend(buf);
-
-                    found
-                } else {
-                    found
-                };
-
-                if self.read_buffer.len() > NUM_GARBAGE_CONTENT_LIMIT + NUM_GARBAGE_TERMINATOR_BYTES
-                {
-                    return (state, Err(GarbageLimitExceededError));
-                }
-
-                if found {
-                    // Here, we expect self.read_buffer to contain the garbage, including the
-                    // terminator
-
-                    let currlen = self.read_buffer.len();
-                    let garbage_len = currlen - other_garbage_terminator.len();
-                    let lhs = cmp::max(prevlen, insurance_len) - insurance_len;
-                    let new_range = lhs..garbage_len;
-                    relay_out
-                        .write_garbage(&self.read_buffer[new_range])
-                        // TODO: replace unwrap
-                        .map_err(|_| "Error writing garbage terminator to relay")
-                        .unwrap();
-                    relay_out.set_eof_garbage();
-
-                    relay_out
-                        .write_terminator(&self.read_buffer[garbage_len..])
-                        // TODO: replace unwrap
-                        .map_err(|_| "Error writing garbage terminator to relay")
-                        .unwrap();
-                    relay_out.set_eof_terminator();
-
-                    let aad: Vec<_> = self.read_buffer.splice(..garbage_len, []).collect();
-                    self.read_buffer.clear();
-
-                    (HandshakeDone(aad), Ok(ProtocolStatus::End))
-                } else {
-                    let currlen = self.read_buffer.len();
-                    let lhs = cmp::max(prevlen, insurance_len) - insurance_len;
-                    let rhs = cmp::max(currlen, insurance_len) - insurance_len;
-                    // The range of data that wasn't relayed and we're sure it's garbage, and is not part of the terminator
-                    let new_range = lhs..rhs;
-                    relay_out
-                        .write_garbage(&self.read_buffer[new_range])
-                        // TODO: replace unwrap
-                        .map_err(|_| "Error writing garbage terminator to relay")
-                        .unwrap();
-
-                    (state, Ok(ProtocolStatus::End))
-                }
-            }
-            state @ HandshakeDone(_) => (state, Ok(ProtocolStatus::End)),
+        // Forward key bytes to relay
+        let key_bytes = self.parser.drain_key_bytes();
+        if !key_bytes.is_empty() {
+            self.relay_out
+                .borrow_mut()
+                .write_key(&key_bytes)
+                .map_err(ReadError)?;
         }
-    }
+        if self.parser.is_key_eof() {
+            self.relay_out.borrow_mut().set_eof_key();
+        }
 
-    fn take_state(&mut self) -> Self::State {
-        self.state.take().unwrap()
-    }
+        // Forward garbage bytes to relay
+        let garbage_bytes = self.parser.drain_garbage_bytes();
+        if !garbage_bytes.is_empty() {
+            self.relay_out
+                .borrow_mut()
+                .write_garbage(&garbage_bytes)
+                .map_err(ReadError)?;
+        }
+        if self.parser.is_garbage_eof() {
+            self.relay_out.borrow_mut().set_eof_garbage();
+        }
 
-    fn set_state(&mut self, state: Self::State) {
-        self.state = Some(state);
+        // Forward terminator bytes to relay
+        let terminator_bytes = self.parser.drain_terminator_bytes();
+        if !terminator_bytes.is_empty() {
+            self.relay_out
+                .borrow_mut()
+                .write_terminator(&terminator_bytes)
+                .map_err(ReadError)?;
+            self.relay_out.borrow_mut().set_eof_terminator();
+        }
+
+        // Update shared garbage_terminator_to_send when the ECDH-derived terminator is ready
+        if let Some(term) = self.parser.outbound_garbage_terminator() {
+            let term_clone = term.to_vec();
+            *self.garbage_terminator_to_send.borrow_mut() = term_clone;
+        }
+
+        Ok(status)
     }
 }
 
+
+
 pub struct MitmHandshakeImpersonatorLegWriter {
-    state: Option<HandshakeRelayPeerState>,
-
+    pub parser: HandshakeWriteParser,
     relay_in: Rc<RefCell<dyn FakePeerRelayReader>>,
-
-    key_to_send: Rc<RefCell<Vec<u8>>>,
-    cipher: Rc<RefCell<Option<CipherSession>>>,
     garbage_terminator_to_send: Rc<RefCell<Vec<u8>>>,
 }
 
 impl MitmHandshakeImpersonatorLegWriter {
     pub fn new(
         relay_in: Rc<RefCell<dyn FakePeerRelayReader>>,
-        key_to_send: Rc<RefCell<Vec<u8>>>,
-        cipher: Rc<RefCell<Option<CipherSession>>>,
+        key_bytes: Vec<u8>,
         garbage_terminator_to_send: Rc<RefCell<Vec<u8>>>,
     ) -> Self {
+        let parser = HandshakeWriteParser::new(key_bytes);
         Self {
-            state: Some(HandshakeRelayPeerState::new()),
+            parser,
             relay_in,
-            key_to_send,
-            cipher,
             garbage_terminator_to_send,
         }
     }
 
     pub fn is_final(&self) -> bool {
-        if let Some(state) = &self.state {
-            state.is_final()
-        } else {
-            false
-        }
+        self.parser.is_done()
     }
 
-    pub fn next_phase(self) -> Option<MitmImpersonatorLegWriter> {
-        if !self.is_final() {
-            return None;
-        };
-
-        // TODO: replace unwrap
-        let outbound_cipher = self
-            .cipher
-            .borrow_mut()
-            .as_mut()
-            .unwrap()
-            .consume_outbound()
-            .unwrap();
-
-        Some(MitmImpersonatorLegWriter::new(
-            self.relay_in,
-            outbound_cipher,
-        ))
+    pub fn next_phase(mut self) -> Option<MitmImpersonatorLegWriter> {
+        let outbound_cipher = self.parser.take_outbound_cipher()?;
+        Some(MitmImpersonatorLegWriter::new(self.relay_in, outbound_cipher))
     }
 }
 
-impl ProtocolWriteParser for MitmHandshakeImpersonatorLegWriter {
-    type State = HandshakeRelayPeerState;
+impl StreamWriteParser for MitmHandshakeImpersonatorLegWriter {
     type Error = ();
 
-    fn transition(
-        &mut self,
-        state: Self::State,
-        data: &mut dyn BufWriter,
-    ) -> (Self::State, Result<ProtocolStatus, Self::Error>) {
-        use HandshakeRelayPeerState::*;
-
-        match state {
-            state @ SendingKey => {
-                let mut key_to_send = self.key_to_send.borrow_mut();
-
-                let limit = cmp::min(data.remaining(), key_to_send.len());
-                let mut _key_buf = vec![0u8; limit];
-                // TODO: replace unwrap
-                let size = self.relay_in.borrow_mut().read_key(&mut _key_buf).unwrap();
-
-                data.write_all(&key_to_send[..size]).unwrap();
-                key_to_send.splice(..size, []);
-
-                if key_to_send.is_empty() {
-                    (SendingGarbage, Ok(ProtocolStatus::Continue))
-                } else {
-                    (state, Ok(ProtocolStatus::End))
-                }
+    fn step(&mut self, data: &mut dyn BufWriter) -> Result<ProtocolStatus, Self::Error> {
+        if self.parser.is_sending_key() {
+            // Pacing: only write as many key bytes as the real peer has signalled
+            let available = self.relay_in.borrow().peek_len_key();
+            if available == 0 {
+                return Ok(ProtocolStatus::End);
             }
-            state @ SendingGarbage => {
-                let limit = data.remaining();
-                let mut buf = vec![0u8; limit];
-                // TODO: replace unwrap
-                let size = self.relay_in.borrow_mut().read_garbage(&mut buf).unwrap();
-
-                data.write_all(&buf[..size]).unwrap();
-
-                if self.relay_in.borrow().peek_len_garbage() == 0
-                    && self.relay_in.borrow().is_eof_garbage()
-                {
-                    (SendingGarbageTerminator, Ok(ProtocolStatus::Continue))
-                } else {
-                    (state, Ok(ProtocolStatus::End))
-                }
+            let limit = cmp::min(available, data.remaining());
+            let mut pacing_buf = vec![0u8; limit];
+            let size = self.relay_in.borrow_mut().read_key(&mut pacing_buf).unwrap();
+            if size == 0 {
+                return Ok(ProtocolStatus::End);
             }
-            state @ SendingGarbageTerminator => {
-                let mut garbage_terminator_to_send = self.garbage_terminator_to_send.borrow_mut();
-                let limit = cmp::min(data.remaining(), garbage_terminator_to_send.len());
-                let mut _terminator_buf = vec![0u8; limit];
-                let size = self
-                    .relay_in
-                    .borrow_mut()
-                    // TODO: replace unwrap
-                    .read_terminator(&mut _terminator_buf)
-                    .unwrap();
-
-                // The terminator is replaced by ours. We're not using the original one
-                data.write_all(&garbage_terminator_to_send[..size]).unwrap();
-                garbage_terminator_to_send.splice(..size, []);
-
-                if garbage_terminator_to_send.is_empty() {
-                    (HandshakeDone, Ok(ProtocolStatus::End))
-                } else {
-                    (state, Ok(ProtocolStatus::End))
-                }
-            }
-            state @ HandshakeDone => (state, Ok(ProtocolStatus::End)),
+            let mut limited = LimitedWriter { inner: data, limit: size };
+            return self.parser.step(&mut limited);
         }
-    }
 
-    fn take_state(&mut self) -> Self::State {
-        self.state.take().unwrap()
-    }
+        if self.parser.is_sending_garbage() {
+            // Push available relay garbage into parser, then step
+            let available = self.relay_in.borrow().peek_len_garbage();
+            if available > 0 {
+                let mut buf = vec![0u8; available];
+                let size = self.relay_in.borrow_mut().read_garbage(&mut buf).unwrap();
+                self.parser.push_garbage_bytes(&buf[..size]);
+            }
+            if self.relay_in.borrow().is_eof_garbage() {
+                self.parser.set_garbage_eof();
+            }
+        }
 
-    fn set_state(&mut self, state: Self::State) {
-        self.state = Some(state);
+        if self.parser.is_sending_terminator() {
+            // Ensure parser has the outbound garbage terminator before writing
+            let term = self.garbage_terminator_to_send.borrow().clone();
+            if !term.is_empty() {
+                self.parser.set_terminator(&term);
+            }
+            // Pacing: only write as many terminator bytes as the real peer has sent
+            let available = self.relay_in.borrow().peek_len_terminator();
+            if available == 0 {
+                return Ok(ProtocolStatus::End);
+            }
+            let limit = cmp::min(available, data.remaining());
+            let mut pacing_buf = vec![0u8; limit];
+            let size = self
+                .relay_in
+                .borrow_mut()
+                .read_terminator(&mut pacing_buf)
+                .unwrap();
+            if size == 0 {
+                return Ok(ProtocolStatus::End);
+            }
+            let mut limited = LimitedWriter { inner: data, limit: size };
+            return self.parser.step(&mut limited);
+        }
+
+        self.parser.step(data)
     }
 }
 
 pub struct MitmImpersonatorLegReader {
-    state: Option<DataBIP324State>,
-    remaining: usize,
-    aad: Vec<u8>,
-
-    inbound_cipher: InboundCipher,
-
+    parser: DataReadParser,
     relay_out: Rc<RefCell<dyn FakePeerRelayWriter>>,
 }
 
@@ -761,163 +524,45 @@ impl MitmImpersonatorLegReader {
     pub fn new(
         aad: AADType,
         relay_out: Rc<RefCell<dyn FakePeerRelayWriter>>,
-        mut inbound_cipher: InboundCipher,
+        inbound_cipher: InboundCipher,
     ) -> Self {
-        let length_decryptor = inbound_cipher
-            .get_new_length_decryptor()
-            .expect("The inbound cipher can't create a length decryptor");
+        let parser = DataReadParser::new(aad.clone(), inbound_cipher);
         relay_out.borrow_mut().set_aad(&aad);
-        Self {
-            state: Some(DataBIP324State::ReceivingPacketLen(length_decryptor)),
-            remaining: NUM_LENGTH_BYTES,
-            aad,
-            inbound_cipher,
-            relay_out,
-        }
-    }
-
-    fn consume_aad(&mut self) -> Vec<u8> {
-        self.aad.drain(..).collect()
-    }
-
-    pub fn set_aad(&mut self, aad: Vec<u8>) {
-        self.aad = aad;
+        Self { parser, relay_out }
     }
 }
 
-impl ProtocolReadParser for MitmImpersonatorLegReader {
-    type State = DataBIP324State;
+impl StreamReadParser for MitmImpersonatorLegReader {
     type Error = ();
 
-    fn transition(
-        &mut self,
-        state: Self::State,
-        data: &mut dyn BufReader,
-    ) -> (Self::State, Result<ProtocolStatus, Self::Error>) {
-        use DataBIP324State::*;
+    fn step(&mut self, data: &mut dyn BufReader) -> Result<ProtocolStatus, Self::Error> {
+        let status = self.parser.step(data)?;
 
-        let data_buf = data.buf_ref();
-        let to_consume = cmp::min(self.remaining, data_buf.len());
-        let mut data_to_process = data_buf[..to_consume].to_vec();
-        self.remaining -= to_consume;
-
-        let (next_state, res) = match state {
-            ReceivingPacketLen(mut length_decryptor) => {
-                // TODO: replace unwrap
-                length_decryptor
-                    .decrypt_len_part_inplace(&mut data_to_process)
-                    .unwrap();
-
-                self.relay_out
-                    .borrow_mut()
-                    .write_length_bytes(&data_to_process);
-
-                match length_decryptor.try_end() {
-                    Ok((length_cipher, packet_len)) => {
-                        // TODO: replace unwrap
-                        self.inbound_cipher
-                            .reown_length_cipher(length_cipher)
-                            .unwrap();
-
-                        if packet_len > MAX_PACKET_SIZE_FOR_ALLOCATION {
-                            // TODO: replace panic
-                            panic!("Packet too big");
-                        }
-
-                        let stream_cipher = self
-                            .inbound_cipher
-                            .packet_cipher
-                            .start_one_payload_stream_encryption();
-
-                        // Add 1 for the header byte, which is not included in the length
-                        self.remaining = packet_len + 1;
-                        (
-                            ReceivingPacketContent(stream_cipher),
-                            Ok(ProtocolStatus::Continue),
-                        )
-                    }
-                    // This is just the initial length_decryptor
-                    // We have this weird pattern because we want the length decryptor to be
-                    // consumed conditionally (only when when length_decryptor received all the
-                    // necessary bytes)
-                    Err(new_length_decryptor) => (
-                        ReceivingPacketLen(new_length_decryptor),
-                        Ok(ProtocolStatus::End),
-                    ),
-                }
-            }
-            ReceivingPacketContent(mut stream_cipher) => {
-                stream_cipher.decrypt_and_store_chunk(&mut data_to_process);
-                self.relay_out
-                    .borrow_mut()
-                    .write_data_bytes(&data_to_process);
-
-                if self.remaining == 0 {
-                    let aad = self.consume_aad();
-                    let tag = stream_cipher.get_tag(Some(&aad[..]));
-
-                    self.remaining = NUM_TAG_BYTES;
-                    (
-                        ReceivingPacketTag(tag.to_vec()),
-                        Ok(ProtocolStatus::Continue),
-                    )
-                } else {
-                    (
-                        ReceivingPacketContent(stream_cipher),
-                        Ok(ProtocolStatus::End),
-                    )
-                }
-            }
-            ReceivingPacketTag(mut expected_tag) => {
-                if data_to_process != expected_tag[..data_to_process.len()] {
-                    // TODO: replace panic
-                    panic!("AEAD tag check fail");
-                }
-                expected_tag.drain(..data_to_process.len());
-
-                self.relay_out
-                    .borrow_mut()
-                    .write_tag_bytes(&data_to_process);
-                if self.remaining == 0 {
-                    let length_decryptor = self
-                        .inbound_cipher
-                        .get_new_length_decryptor()
-                        .expect("The inbound cipher can't create a length decryptor");
-
-                    self.remaining = NUM_LENGTH_BYTES;
-                    (
-                        ReceivingPacketLen(length_decryptor),
-                        Ok(ProtocolStatus::Continue),
-                    )
-                } else {
-                    (ReceivingPacketTag(expected_tag), Ok(ProtocolStatus::End))
-                }
-            }
-        };
-
-        if res.is_ok() {
-            let _ = data.read(&mut vec![0u8; to_consume]).unwrap();
-        } else {
-            // TODO: see if you can represent this through typing
-            self.remaining += to_consume;
+        let length_bytes = self.parser.drain_length_bytes();
+        if !length_bytes.is_empty() {
+            self.relay_out.borrow_mut().write_length_bytes(&length_bytes);
         }
 
-        (next_state, res)
-    }
+        let data_bytes = self.parser.drain_data_bytes();
+        if !data_bytes.is_empty() {
+            self.relay_out.borrow_mut().write_data_bytes(&data_bytes);
+        }
 
-    fn take_state(&mut self) -> Self::State {
-        self.state.take().unwrap()
-    }
+        let tag_bytes = self.parser.drain_tag_bytes();
+        if !tag_bytes.is_empty() {
+            self.relay_out.borrow_mut().write_tag_bytes(&tag_bytes);
+        }
 
-    fn set_state(&mut self, state: Self::State) {
-        self.state = Some(state);
+        if let Some(aad) = self.parser.take_aad() {
+            self.relay_out.borrow_mut().set_aad(&aad);
+        }
+
+        Ok(status)
     }
 }
 
 pub struct MitmImpersonatorLegWriter {
-    state: Option<LegWriterState>,
-
-    outbound_cipher: OutboundCipher,
+    parser: DataWriteParser,
     relay_in: Rc<RefCell<dyn FakePeerRelayReader>>,
 }
 
@@ -926,124 +571,50 @@ impl MitmImpersonatorLegWriter {
         relay_in: Rc<RefCell<dyn FakePeerRelayReader>>,
         outbound_cipher: OutboundCipher,
     ) -> Self {
-        Self {
-            state: Some(LegWriterState::new()),
-            outbound_cipher,
-            relay_in,
-        }
+        let parser = DataWriteParser::new(outbound_cipher);
+        Self { parser, relay_in }
     }
 }
 
-impl ProtocolWriteParser for MitmImpersonatorLegWriter {
-    type State = LegWriterState;
+impl StreamWriteParser for MitmImpersonatorLegWriter {
     type Error = ();
 
-    fn transition(
-        &mut self,
-        state: Self::State,
-        data: &mut dyn BufWriter,
-    ) -> (Self::State, Result<ProtocolStatus, Self::Error>) {
-        use LegWriterState::*;
-
-        let mut relay_in = self.relay_in.borrow_mut();
-
-        match state {
-            SendingLength(remaining, written) => {
-                // TODO: replace unwrap
-                let buf = data.prewrite(relay_in.peek_length_bytes()).unwrap();
-
-                let size = relay_in.read_length_bytes(buf);
-                if size > remaining {
-                    // TODO: replace panic
-                    panic!("Received too many length bytes from the input relay");
-                }
-
-                // Append the written data before encrypting it
-                let new_written = [&written[..], &buf[..size]].concat();
-
-                self.outbound_cipher
-                    .encrypt_len_part_inplace(&mut buf[..size]);
-
-                if size == remaining {
-                    let length_bytes: [u8; 8] =
-                        [new_written, vec![0u8; 5]].concat().try_into().unwrap();
-                    // Add 1 for the header, which is not included in the length
-                    let payload_len = 1 + usize::from_le_bytes(length_bytes);
-                    let stream_cipher = self
-                        .outbound_cipher
-                        .packet_cipher
-                        .start_one_payload_stream_encryption();
-
-                    (
-                        SendingPayload(payload_len, stream_cipher),
-                        Ok(ProtocolStatus::Continue),
-                    )
-                } else {
-                    let new_remaining = remaining - size;
-                    (
-                        SendingLength(new_remaining, new_written),
-                        Ok(ProtocolStatus::End),
-                    )
-                }
-            }
-            SendingPayload(remaining, mut stream_cipher) => {
-                // TODO: replace unwrap
-                let buf = data.prewrite(relay_in.peek_data_bytes()).unwrap();
-
-                let size = relay_in.read_data_bytes(buf);
-                // TODO: replace panic
-                if size > remaining {
-                    panic!("Received too many data bytes from the input relay");
-                }
-
-                stream_cipher.encrypt_and_store_chunk(&mut buf[..size]);
-
-                if size == remaining {
-                    let aad = relay_in.read_aad().unwrap_or(vec![]);
-                    let tag = stream_cipher.get_tag(Some(&aad));
-                    self.outbound_cipher.packet_cipher.end_current_stream(&aad);
-                    (SendingTag(tag.to_vec()), Ok(ProtocolStatus::Continue))
-                } else {
-                    (
-                        SendingPayload(remaining - size, stream_cipher),
-                        Ok(ProtocolStatus::End),
-                    )
-                }
-            }
-            SendingTag(mut tag) => {
-                // TODO: replace unwrap
-                let buf = data.prewrite(relay_in.peek_tag_bytes()).unwrap();
-
-                let size = relay_in.read_tag_bytes(buf);
-                if size > tag.len() {
-                    // TODO: replace panic
-                    panic!("Received too many tag bytes from the input relay");
-                }
-
-                // Overwrite with our own tag
-                buf[..size].copy_from_slice(&tag.drain(0..size).collect::<Vec<_>>());
-
-                if tag.is_empty() {
-                    (
-                        SendingLength(NUM_LENGTH_BYTES, vec![]),
-                        Ok(ProtocolStatus::Continue),
-                    )
-                } else {
-                    (SendingTag(tag), Ok(ProtocolStatus::End))
-                }
+    fn step(&mut self, data: &mut dyn BufWriter) -> Result<ProtocolStatus, Self::Error> {
+        // Only push new bytes from relay when the parser has consumed the previous segment.
+        // This prevents mixing bytes from different packets into the same parser input buffer.
+        if self.parser.peek_input_length_bytes() == 0 {
+            let available = self.relay_in.borrow().peek_length_bytes();
+            if available > 0 {
+                let mut buf = vec![0u8; available];
+                let size = self.relay_in.borrow_mut().read_length_bytes(&mut buf);
+                self.parser.push_length_bytes(&buf[..size]);
             }
         }
-    }
+        if self.parser.peek_input_data_bytes() == 0 {
+            let available = self.relay_in.borrow().peek_data_bytes();
+            if available > 0 {
+                let mut buf = vec![0u8; available];
+                let size = self.relay_in.borrow_mut().read_data_bytes(&mut buf);
+                self.parser.push_data_bytes(&buf[..size]);
+            }
+        }
+        if self.parser.peek_input_tag_bytes() == 0 {
+            let available = self.relay_in.borrow().peek_tag_bytes();
+            if available > 0 {
+                let mut buf = vec![0u8; available];
+                let size = self.relay_in.borrow_mut().read_tag_bytes(&mut buf);
+                self.parser.push_tag_bytes(&buf[..size]);
+            }
+        }
+        if let Some(aad) = self.relay_in.borrow_mut().read_aad() {
+            self.parser.set_aad(&aad);
+        }
 
-    fn take_state(&mut self) -> Self::State {
-        // TODO: remove unwrap
-        self.state.take().unwrap()
-    }
-
-    fn set_state(&mut self, state: Self::State) {
-        self.state = Some(state);
+        self.parser.step(data)
     }
 }
+
+
 
 pub fn key_from_rng<Rng: RngCore + CryptoRng>(rng: &mut Rng) -> Result<EcdhPoint, Box<dyn Error>> {
     let mut secret_key_buffer = [0u8; 32];
@@ -1305,8 +876,8 @@ mod mitmfakepeerbip324_tests {
     use secp256k1::rand::rngs::mock::StepRng;
     use std::str::FromStr;
 
-    use crate::cipher::{InboundCipher, OutboundCipher, SessionKeyMaterial};
-    use crate::protocol::{NUM_GARBAGE_TERMINATOR_BYTES, PacketType};
+    use crate::cipher::{CipherSession, InboundCipher, OutboundCipher, SessionKeyMaterial};
+    use crate::protocol::{NUM_GARBAGE_TERMINATOR_BYTES, NUM_LENGTH_BYTES, PacketType};
 
     macro_rules! test_data {
         ($varname:ident, $name:ident { $($field:ident: $ty:ty = $val:expr),* $(,)? }) => {
@@ -1565,15 +1136,10 @@ mod mitmfakepeerbip324_tests {
         server
             .consume(&mut bufref)
             .expect("Error on pass_peer_data");
-        assert!(matches!(
-            server.reader_leg_state,
-            Some(ReaderLegState::Handshake(
-                MitmHandshakeImpersonatorLegReader {
-                    state: Some(HandshakeBIP324State::ReceivingKey(..)),
-                    ..
-                }
-            ))
-        ));
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
+            panic!("Expected handshake state");
+        };
+        assert!(reader_leg.is_receiving_key());
 
         // Send another key byte
         let buf = [0xa3];
@@ -1581,15 +1147,10 @@ mod mitmfakepeerbip324_tests {
         server
             .consume(&mut bufref)
             .expect("Error on pass_peer_data");
-        assert!(matches!(
-            server.reader_leg_state,
-            Some(ReaderLegState::Handshake(
-                MitmHandshakeImpersonatorLegReader {
-                    state: Some(HandshakeBIP324State::ReceivingKey(..)),
-                    ..
-                }
-            ))
-        ));
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
+            panic!("Expected handshake state");
+        };
+        assert!(reader_leg.is_receiving_key());
 
         // Send all the key bytes, except for the last one
         let buf = [0x73; NUM_ELLIGATOR_SWIFT_BYTES - 2 - 1];
@@ -1597,15 +1158,10 @@ mod mitmfakepeerbip324_tests {
         server
             .consume(&mut bufref)
             .expect("Error on pass_peer_data");
-        assert!(matches!(
-            server.reader_leg_state,
-            Some(ReaderLegState::Handshake(
-                MitmHandshakeImpersonatorLegReader {
-                    state: Some(HandshakeBIP324State::ReceivingKey(..)),
-                    ..
-                }
-            ))
-        ));
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
+            panic!("Expected handshake state");
+        };
+        assert!(reader_leg.is_receiving_key());
 
         // Send all the key bytes, except for the last one
         let buf = [0x29];
@@ -1613,15 +1169,10 @@ mod mitmfakepeerbip324_tests {
         server
             .consume(&mut bufref)
             .expect("Error on pass_peer_data");
-        assert!(matches!(
-            server.reader_leg_state,
-            Some(ReaderLegState::Handshake(
-                MitmHandshakeImpersonatorLegReader {
-                    state: Some(HandshakeBIP324State::ReceivingGarbage(..)),
-                    ..
-                }
-            ))
-        ));
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
+            panic!("Expected handshake state");
+        };
+        assert!(reader_leg.is_receiving_garbage());
     }
 
     #[test]
@@ -1634,15 +1185,10 @@ mod mitmfakepeerbip324_tests {
         server
             .consume(&mut bufref)
             .expect("Error on pass_peer_data");
-        assert!(matches!(
-            server.reader_leg_state,
-            Some(ReaderLegState::Handshake(
-                MitmHandshakeImpersonatorLegReader {
-                    state: Some(HandshakeBIP324State::ReceivingGarbage(..)),
-                    ..
-                }
-            ))
-        ));
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
+            panic!("Expected handshake state");
+        };
+        assert!(reader_leg.is_receiving_garbage());
     }
 
     #[test]
@@ -1655,15 +1201,10 @@ mod mitmfakepeerbip324_tests {
         server
             .consume(&mut bufref)
             .expect("Error on pass_peer_data");
-        assert!(matches!(
-            server.reader_leg_state,
-            Some(ReaderLegState::Handshake(
-                MitmHandshakeImpersonatorLegReader {
-                    state: Some(HandshakeBIP324State::ReceivingGarbage(..)),
-                    ..
-                }
-            ))
-        ));
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
+            panic!("Expected handshake state");
+        };
+        assert!(reader_leg.is_receiving_garbage());
     }
 
     // Tests that the fake server doesn't relay the key if the real server
@@ -1678,15 +1219,10 @@ mod mitmfakepeerbip324_tests {
         server
             .consume(&mut bufref)
             .expect("Error on pass_peer_data");
-        assert!(matches!(
-            server.reader_leg_state,
-            Some(ReaderLegState::Handshake(
-                MitmHandshakeImpersonatorLegReader {
-                    state: Some(HandshakeBIP324State::ReceivingGarbage(..)),
-                    ..
-                }
-            ))
-        ));
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
+            panic!("Expected handshake state");
+        };
+        assert!(reader_leg.is_receiving_garbage());
 
         let mut buf = vec![0u8; NUM_ELLIGATOR_SWIFT_BYTES];
         let buf_len = buf.len();
@@ -1729,21 +1265,19 @@ mod mitmfakepeerbip324_tests {
             .consume(&mut client_keyref)
             .expect("Error on pass_peer_data");
 
-        let Some(ReaderLegState::Handshake(reader_leg)) = &server.reader_leg_state else {
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
             panic!("Wrong leg state");
         };
-        let Some(HandshakeBIP324State::ReceivingGarbage(other_garbage_terminator)) =
-            reader_leg.state
-        else {
-            panic!("Wrong state after receiving key");
-        };
+        assert!(reader_leg.is_receiving_garbage());
+        let other_garbage_terminator = *reader_leg
+            .inbound_garbage_terminator()
+            .expect("Expected garbage terminator to be set");
 
-        let Some(ReaderLegState::Handshake(reader_leg)) = server.reader_leg_state else {
+        let Some(ReaderLegState::Handshake(ref mut reader_leg)) = server.reader_leg_state else {
             panic!("Wrong leg state");
         };
 
-        let cipher = reader_leg.cipher.borrow_mut().take().unwrap();
-        let (inbound_cipher, outbound_cipher) = cipher.into_split();
+        let (inbound_cipher, outbound_cipher) = reader_leg.parser.take_ciphers().unwrap();
 
         assert_eq!(inbound_cipher.length_cipher.unwrap().key_bytes, initiator_l);
         assert_eq!(inbound_cipher.packet_cipher.key_bytes, initiator_p);
@@ -1764,15 +1298,10 @@ mod mitmfakepeerbip324_tests {
         server
             .consume(&mut bufref)
             .expect("Error on pass_peer_data");
-        assert!(matches!(
-            server.reader_leg_state,
-            Some(ReaderLegState::Handshake(
-                MitmHandshakeImpersonatorLegReader {
-                    state: Some(HandshakeBIP324State::ReceivingGarbage(..)),
-                    ..
-                }
-            ))
-        ));
+        let Some(ReaderLegState::Handshake(ref reader_leg)) = server.reader_leg_state else {
+            panic!("Expected handshake state");
+        };
+        assert!(reader_leg.is_receiving_garbage());
 
         let buf = [0u8];
         let mut out_buf = [0u8; NUM_ELLIGATOR_SWIFT_BYTES];


### PR DESCRIPTION
Closes #5. Follows the implementation plan mentioned [here](https://github.com/RazorBest/bip324-mitm/issues/5#issuecomment-4213961521). `CipherSession` is owned by Protocol layer, not the MITM layer as advised. 

All 19 pre-existing MITM integration tests continue to pass. 43 new unit and integration tests were added across the four parsers and mod.rs. These pass showing that the bip324 module works with no MitmImpersonatorLeg, FakePeerRelay, or shared-state infrastructure.

I’m happy to work on any changes or improvements based on your feedback @RazorBest 